### PR TITLE
add Dockerfile and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 #*
 site.log
+privacypatterns.wiki

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:alpine
+
+COPY ./deploy /html
+WORKDIR /html
+
+CMD ["python", "-m", "http.server", "80"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := /bin/bash
+.PHONY: build wiki-clone docker static
+
+build: ./site/content/patterns
+static: ./site/deploy
+
+docker:
+	@docker build .
+
+./privacypatterns.wiki: wiki-clone
+	@echo "Updating content from wiki"
+	@[ -d $@ ] || git clone https://github.com/privacypatterns/$@.git
+	@cd $@ && git checkout master && git pull
+
+./site/content/patterns: ./privacypatterns.wiki
+	@echo "Generating static files"
+	@python markdown_to_hyde.py -s ./privacypatterns.wiki -d ./site/content/
+
+./hyde/hyde.py:
+	@echo "Getting hyde"
+	@git submodule init
+	@git submodule update
+	# check if python dependencies are installed
+
+./site/deploy: ./site/content/patterns ./hyde/hyde.py
+	@python ./hyde/hyde.py -g -s ./site


### PR DESCRIPTION
makes it easier to rebuild and create a runnable container.

Now supports

`make build`: pulls the wiki and updates the content in the main repo with new changes
`make static`: creates the deployable static html pages
`make docker`: creates a docker container with the static html pages that can be run using `docker run <image-id>` to serve the site

Still some improvements around python dependencies for hyde are required. 