### PR TITLE
Add Unusual Activities patterns from wiki

### DIFF
--- a/site/content/patterns/Private-link.md
+++ b/site/content/patterns/Private-link.md
@@ -10,6 +10,9 @@ When private content is accessible online, especially granular resources, and us
 
 ##Problem##
 
+How do you share a private resource with unauthenticated users in a way that respects its sensitivity?
+The solution must not allow unauthenticated users to access resources that weren't intended to be shared. 
+
 ##Solution##
 
 Provide the user a _private link_ or _unguessable URL_ for a particular set of their personal information (their current location, an album of photos). Anyone who has the link may access the information, but the link is not posted publicly or easily guessable by an outsider, so the information is not shared with all. The user can share the private link with friends, family or other trusted contacts who can in turn forward the link to others who will be able to access it, without any account authentication or access control lists.
@@ -23,6 +26,8 @@ Services may also allow users to revoke existing private links or change the URL
 #### Google "anyone with the link" sharing ####
 
 #### Tripit "Get a link" ####
+
+#### Dropbox "Share Link" ####
 
 ##Forces/Concerns##
 

--- a/site/content/patterns/Unusual-activities.html
+++ b/site/content/patterns/Unusual-activities.html
@@ -1,0 +1,26 @@
+{% extends "_post.html" %}
+
+{%hyde
+
+title: Handling unusual account activities with multiple factors
+
+type: pattern
+
+excerpt: Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.
+
+categories: 
+  - control
+  - notice
+  - authentication
+
+status: draft
+
+address: weisi@cmu.edu
+
+%}
+
+{% block article %}
+
+{% include 'patterns/Unusual-activities.md' %}
+
+{% endblock %}

--- a/site/content/patterns/Unusual-activities.md
+++ b/site/content/patterns/Unusual-activities.md
@@ -1,0 +1,250 @@
+[TOC]
+
+## Intent
+
+For Internet services, prevent suspicious access to the account, and/or
+make the account owner aware of unusual activities.
+
+## Context
+
+Many Internet services are using password-based authentication which is
+really convenient (compared to strong authentication) but has apparent
+drawbacks:
+
+-   The password itself does not change.
+
+    Unless the account owner changes the password, all sign-ins use the
+    same identity-password combination. If the password is stolen by a
+    malicious party through some means, it can be reused until it is
+    changed.
+
+-   The password can be cracked.
+
+    Many account owners tend to use weak passwords that can be
+    brute-force attacked online. Sometimes the hacker can obtain the
+    database dump which contains hashed passwords, which can be
+    brute-forced offline.
+
+-   The account owner has no way to ensure their exclusive possession of
+    the password.
+
+    The account owner has no evidence if the password is stolen by a
+    malicious party.
+
+-   The only way to control who can access is to reset the password.
+
+    As a result, if the account owner want to ensure only they have the
+    password, they can only reset the password. In some scenarios,
+    resetting the password is not enough.
+
+-   The password can be seen by people around.
+
+    When the account owner enters the password on a computer keyboard or
+    the screen of a mobile device (mobile phone / tablet), people around
+    have the ability to snoop the password and record it.
+
+Thus, a service can't tell if the user is legitimate even if the
+identity-password combination provided by the user is correct.
+Fortunately, a service can usually receive some meta information to help
+determine if an activity is unusual. In case of such unusual activities,
+a service needs to prevent suspicious access to an account, and/or
+inform the account owner of the unusual activities.
+
+## Problem
+
+How can a service that uses username-password authentication and
+involves a lot of privacy identify unusual sign-ins, confirm the
+identify of the user, and inform the account owner of such unusual
+activities?
+
+## Solutions
+
+First, the service should be able to identify unusual sign-ins Then the
+service may use multi-factor authentication to confirm the identity of
+the user.
+
+The user should be informed of unusual activites, or have some ways to
+see recent events, and even do something.
+
+### Identify Unusual Activities
+
+Today, a web service may appear as a website or an application on the
+user's devices (including mobile devices and the PCs). The service can
+use meta information to determine if a sign-in with the correct
+username-password combination is suspicious.
+
+The strategies described here has both false positives and false
+negatives.
+
+#### A Website
+
+Typically, a sign-in to a website is in the form of an HTTP request,
+which contains many customized settings of the browser, including the
+type of the browser and operating system as well as the architecture
+(`User-Agent` header), the Cookie (`Cookie` header), language
+preferences (`Accept-Languages` header). Apart from these, the website
+can get the IP address of the user, which may be mapped to a certain
+country/area through GeoIP.
+
+The above meta information can be used to tell if a browser is *new* to
+the website. The website can have its rules to determine if an access is
+*suspicious*, for example, an access from a new country / browser /
+operating system is considered suspicious.
+
+#### An Application
+
+By running native code, the application can collect some identifiers of
+the machine, including the operating system environment settings (e.g.
+the list of running processes), the hardware parameters (such as the ID
+of the CPU), and device UUIDs (provided by mobile operating systems like
+iOS). By completing a network request, the service also retrieves the IP
+address of the machine.
+
+The above meta information can be used to tell if a machine is *new* to
+the service. The service can have its rules to determine if a sign-in is
+*suspicious*, for example, an access from a new country / machine /
+operating system is considered suspicious.
+
+### Require Multi-factor Authentication
+
+In case of a suspicious sign-in, multi-factor authentication may be a
+way to let the legitimate user in. The service can request one more
+authentication except password, such as:
+
+-   A software token
+
+    Examples include Google Authenticator which runs on mobile phones
+    and implements RFC6238 TOTP security tokens..
+
+-   A hardware token (disconnected)
+
+    Examples include a token issued by a bank which displays digits,
+    which is similar to a software token.
+
+-   A hardware token (connected)
+
+    The token may exchange a longer secondary password than the previous
+    one, which means it's safer.
+
+-   Personal data like date of birth, SSN
+
+    Obviously not a good choice here because it cannot be changed.
+
+-   An one-time password (OTP) sent to the registered E-mail address /
+    mobile phone
+
+    Depending the type of the service, maybe the user uses the same
+    password for the E-mail address, or maybe the mobile phone is stolen
+    and the service runs on the mobile phone.
+
+Using multi-factor authentication only in case of suspicious sign-ins is
+more convenient to using it all the time, but is less secure.
+
+### Notify Account Holders of Unusual Activities
+
+When an suspicious sign-in is detected, it may be a sign that the
+password has already been leaked. Depending on the type of the service,
+it can notify the user about the suspicious sign-in through E-mail,
+telephone, or other means.
+
+Here the immediate notification can also be used in the multi-factor
+authentication.
+
+For services that can be logged on from multiple devices at the same
+time, the user should be able to check the existence of other sessions,
+and review recent sign-in events.
+
+## Examples
+
+### Gmail
+
+Gmail displays information about other sessions (if any) in the footer,
+linking to a page named "Activity on this account" which lists other
+sessions and recent activities to the Gmail account. The user has the
+option to sign out other sessions.
+
+In case of annoying false positives, the user may choose to disable the
+alert for unusual activity. The disable takes about a week, "to make
+sure the bad guys aren't the ones who turned off your alerts."
+
+### Facebook
+
+When Facebook detects an unusual sign-in, it shows *social
+authentication* that displays a few pictures of the user's friends and
+asks the user to name the person in those photos.
+
+### Dropbox
+
+The *Security* tab of the *Settings* of the Dropbox website displays all
+web browser sessions logged in to the account, and enables the user to
+log out one or more of them. The name of the browser, operating system,
+and the IP address and corresponding country are displayed to help the
+user make a choice.
+
+It also displays all devices that are linked to the account, and allows
+the user to unlink one or more of them.
+
+## Forces/Concerns
+
+The pattern described here is a tradeoff between pure password
+authentication which is insecure, and pure multi-factor authentication
+which is inconvenient. It increases privacy at the cost of usability.
+
+The fallback multi-factor authentication should be picked carefully with
+the understanding of the service.
+
+-   In the above example, Facebook makes use of its resource of
+    friendship and photos. Their decision is based on the assumption
+    that it is very unlikely for a hacker to recognize the friends.
+    Actually the assumption may not hold true in some scenarios, because
+    many of the photos are public and can be viewed under another
+    account, or can be identified with the help from a large-scale
+    tagged photo collection and machine learning.
+-   Persuading the user into carrying a hardware token everywhere only
+    for occasional multi-factor authentication may be difficult, but it
+    might worth the effort for financial services.
+
+The strategy to identify unusual activities should also be considered
+seriously. It should be also to identify most of the activities, with a
+false positive rate that is not too high. It should balance the cost of
+multi-factor authentication.
+
+Reflection on the Process
+-------------------------
+
+### Determining the Scope
+
+I started with Gmail's display of account activities. It displays
+unusual activities regarding an account, which involves identifying
+unusual activities where the password entered is correct. For some other
+services, correct passwords can be rejected from a new device /
+location.
+
+So, the scope of this pattern is to handle unusual activities (including
+sign-ins).
+
+### Relevant Information
+
+This pattern includes multi-factor authentication and two-step
+authentication, which are well studied. But the general topic about
+informing the user of unusual activites seems to be lack of literature.
+
+### Limitations and Discussion
+
+This pattern has some limitations. For example, it relies on accurate
+identification of suspicious sign-ins based on meta information, where
+the meta information including the IP address can be spoofed by an
+experienced attacker.
+
+If the fallback multi-factor authentication only happens occationally to
+the legitimate account owner, they may be unprepared to such
+authentication, leading to a decreased usability.
+
+References
+----------
+
+-   Polakis, I., Lancini, M., Kontaxis, G., Maggi, F., Ioannidis, S.,
+    Keromytis, A. D., & Zanero, S. (2012, December). **All Your Face are
+    Belong to Us: Breaking Facebook's Social Authentication**. In
+    *Proceedings of the 28th Annual Computer Security Applications
+    Conference* (pp. 399-408). ACM.

--- a/site/deploy/categories/access/index.html
+++ b/site/deploy/categories/access/index.html
@@ -95,6 +95,18 @@
   <ul id="patterns_listing">
   
 		<li>
+		  <a href="/patterns/Private-link">
+			  <h3>
+		  		
+						Private link
+					
+				</h3>
+
+				
+			</a>
+		</li>
+  
+		<li>
 		  <a href="/patterns/Privacy-dashboard">
 			  <h3>
 		  		
@@ -104,18 +116,6 @@
 
 				
 					<p>An informational privacy dashboard can provide collected summaries of the collected or processed personal data for a particular user.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Private-link">
-			  <h3>
-		  		
-						Private link
-					
-				</h3>
-
 				
 			</a>
 		</li>

--- a/site/deploy/categories/authentication/index.html
+++ b/site/deploy/categories/authentication/index.html
@@ -82,7 +82,7 @@
 
 
 
-<h1><a href="/patterns" title="Patterns">Patterns</a> &mdash; <span class="category">minimization</span></h1>
+<h1><a href="/patterns" title="Patterns">Patterns</a> &mdash; <span class="category">authentication</span></h1>
   
   <div class="definition">
     
@@ -95,29 +95,15 @@
   <ul id="patterns_listing">
   
 		<li>
-		  <a href="/patterns/Location-granularity">
+		  <a href="/patterns/Unusual-activities">
 			  <h3>
 		  		
-						Location Granularity
+						Handling unusual account activities with multiple factors
 					
 				</h3>
 
 				
-					<p>Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Strip-invisible-metadata">
-			  <h3>
-		  		
-						Strip Invisible Metadata
-					
-				</h3>
-
-				
-					<p>Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p>
+					<p>Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.</p>
 				
 			</a>
 		</li>

--- a/site/deploy/categories/cloud/index.html
+++ b/site/deploy/categories/cloud/index.html
@@ -82,7 +82,7 @@
 
 
 
-<h1><a href="/patterns" title="Patterns">Patterns</a> &mdash; <span class="category">minimization</span></h1>
+<h1><a href="/patterns" title="Patterns">Patterns</a> &mdash; <span class="category">cloud</span></h1>
   
   <div class="definition">
     
@@ -95,29 +95,15 @@
   <ul id="patterns_listing">
   
 		<li>
-		  <a href="/patterns/Location-granularity">
+		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
 		  		
-						Location Granularity
+						Encryption with user-managed keys
 					
 				</h3>
 
 				
-					<p>Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Strip-invisible-metadata">
-			  <h3>
-		  		
-						Strip Invisible Metadata
-					
-				</h3>
-
-				
-					<p>Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p>
+					<p>Use encryption in such a way that the service provider cannot decrypt the user&#39;s information because the user manages the keys.</p>
 				
 			</a>
 		</li>

--- a/site/deploy/categories/control/index.html
+++ b/site/deploy/categories/control/index.html
@@ -95,6 +95,46 @@
   <ul id="patterns_listing">
   
 		<li>
+		  <a href="/patterns/Private-link">
+			  <h3>
+		  		
+						Private link
+					
+				</h3>
+
+				
+			</a>
+		</li>
+  
+		<li>
+		  <a href="/patterns/Unusual-activities">
+			  <h3>
+		  		
+						Handling unusual account activities with multiple factors
+					
+				</h3>
+
+				
+					<p>Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.</p>
+				
+			</a>
+		</li>
+  
+		<li>
+		  <a href="/patterns/Encryption-user-managed-keys">
+			  <h3>
+		  		
+						Encryption with user-managed keys
+					
+				</h3>
+
+				
+					<p>Use encryption in such a way that the service provider cannot decrypt the user&#39;s information because the user manages the keys.</p>
+				
+			</a>
+		</li>
+  
+		<li>
 		  <a href="/patterns/Active-broadcast-of-presence">
 			  <h3>
 		  		
@@ -104,18 +144,6 @@
 
 				
 					<p>Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Private-link">
-			  <h3>
-		  		
-						Private link
-					
-				</h3>
-
 				
 			</a>
 		</li>

--- a/site/deploy/categories/encryption/index.html
+++ b/site/deploy/categories/encryption/index.html
@@ -82,7 +82,7 @@
 
 
 
-<h1><a href="/patterns" title="Patterns">Patterns</a> &mdash; <span class="category">minimization</span></h1>
+<h1><a href="/patterns" title="Patterns">Patterns</a> &mdash; <span class="category">encryption</span></h1>
   
   <div class="definition">
     
@@ -95,29 +95,15 @@
   <ul id="patterns_listing">
   
 		<li>
-		  <a href="/patterns/Location-granularity">
+		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
 		  		
-						Location Granularity
+						Encryption with user-managed keys
 					
 				</h3>
 
 				
-					<p>Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Strip-invisible-metadata">
-			  <h3>
-		  		
-						Strip Invisible Metadata
-					
-				</h3>
-
-				
-					<p>Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p>
+					<p>Use encryption in such a way that the service provider cannot decrypt the user&#39;s information because the user manages the keys.</p>
 				
 			</a>
 		</li>

--- a/site/deploy/categories/index.html
+++ b/site/deploy/categories/index.html
@@ -86,35 +86,43 @@
 	
 		
 
-<ul id="patterns_listing"><li><a href="/patterns/Active-broadcast-of-presence"><h3>
-    		  		
-    						Active broadcast of presence
-    					
-  					</h3><p class="">Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p></a></li><li><a href="/patterns/Ambient-notice"><h3>
-    		  		
-    						Ambient notice
-    					
-  					</h3><p class="">Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p></a></li><li><a href="/patterns/Asynchronous-notice"><h3>
-    		  		
-    						Asynchronous notice
-    					
-  					</h3><p class="">How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p></a></li><li><a href="/patterns/Location-granularity"><h3>
+<ul id="patterns_listing"><li><a href="/patterns/Location-granularity"><h3>
     		  		
     						Location Granularity
     					
-  					</h3><p class="">Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p></a></li><li><a href="/patterns/Privacy-dashboard"><h3>
-    		  		
-    						Privacy dashboard
-    					
-  					</h3><p class="">An informational privacy dashboard can provide collected summaries of the collected or processed personal data for a particular user.</p></a></li><li><a href="/patterns/Private-link"><h3>
+  					</h3><p class="">Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p></a></li><li><a href="/patterns/Private-link"><h3>
     		  		
     						Private link
     					
-  					</h3><p class="empty">No excerpt</p></a></li><li><a href="/patterns/Strip-invisible-metadata"><h3>
+  					</h3><p class="empty">No excerpt</p></a></li><li><a href="/patterns/Privacy-dashboard"><h3>
+    		  		
+    						Privacy dashboard
+    					
+  					</h3><p class="">An informational privacy dashboard can provide collected summaries of the collected or processed personal data for a particular user.</p></a></li><li><a href="/patterns/Unusual-activities"><h3>
+    		  		
+    						Handling unusual account activities with multiple factors
+    					
+  					</h3><p class="">Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.</p></a></li><li><a href="/patterns/Asynchronous-notice"><h3>
+    		  		
+    						Asynchronous notice
+    					
+  					</h3><p class="">How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p></a></li><li><a href="/patterns/Encryption-user-managed-keys"><h3>
+    		  		
+    						Encryption with user-managed keys
+    					
+  					</h3><p class="">Use encryption in such a way that the service provider cannot decrypt the user&#39;s information because the user manages the keys.</p></a></li><li><a href="/patterns/Active-broadcast-of-presence"><h3>
+    		  		
+    						Active broadcast of presence
+    					
+  					</h3><p class="">Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p></a></li><li><a href="/patterns/Strip-invisible-metadata"><h3>
     		  		
     						Strip Invisible Metadata
     					
-  					</h3><p class="">Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p></a></li></ul>
+  					</h3><p class="">Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p></a></li><li><a href="/patterns/Ambient-notice"><h3>
+    		  		
+    						Ambient notice
+    					
+  					</h3><p class="">Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p></a></li></ul>
 
 
 	
@@ -146,6 +154,9 @@
 <a href="/categories/access" class="access">access</a></li>
     
       <li>
+<a href="/categories/authentication" class="authentication">authentication</a></li>
+    
+      <li>
 <a href="/categories/ui" class="ui">ui</a></li>
     
       <li>
@@ -155,7 +166,13 @@
 <a href="/categories/transparency" class="transparency">transparency</a></li>
     
       <li>
+<a href="/categories/encryption" class="encryption">encryption</a></li>
+    
+      <li>
 <a href="/categories/distribution" class="distribution">distribution</a></li>
+    
+      <li>
+<a href="/categories/cloud" class="cloud">cloud</a></li>
     
       <li>
 <a href="/categories/metadata" class="metadata">metadata</a></li>

--- a/site/deploy/categories/location/index.html
+++ b/site/deploy/categories/location/index.html
@@ -99,48 +99,6 @@
   <ul id="patterns_listing">
   
 		<li>
-		  <a href="/patterns/Active-broadcast-of-presence">
-			  <h3>
-		  		
-						Active broadcast of presence
-					
-				</h3>
-
-				
-					<p>Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Ambient-notice">
-			  <h3>
-		  		
-						Ambient notice
-					
-				</h3>
-
-				
-					<p>Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Asynchronous-notice">
-			  <h3>
-		  		
-						Asynchronous notice
-					
-				</h3>
-
-				
-					<p>How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p>
-				
-			</a>
-		</li>
-  
-		<li>
 		  <a href="/patterns/Location-granularity">
 			  <h3>
 		  		
@@ -169,6 +127,34 @@
 		</li>
   
 		<li>
+		  <a href="/patterns/Asynchronous-notice">
+			  <h3>
+		  		
+						Asynchronous notice
+					
+				</h3>
+
+				
+					<p>How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p>
+				
+			</a>
+		</li>
+  
+		<li>
+		  <a href="/patterns/Active-broadcast-of-presence">
+			  <h3>
+		  		
+						Active broadcast of presence
+					
+				</h3>
+
+				
+					<p>Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p>
+				
+			</a>
+		</li>
+  
+		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
 		  		
@@ -178,6 +164,20 @@
 
 				
 					<p>Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p>
+				
+			</a>
+		</li>
+  
+		<li>
+		  <a href="/patterns/Ambient-notice">
+			  <h3>
+		  		
+						Ambient notice
+					
+				</h3>
+
+				
+					<p>Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p>
 				
 			</a>
 		</li>

--- a/site/deploy/categories/mobile/index.html
+++ b/site/deploy/categories/mobile/index.html
@@ -95,6 +95,34 @@
   <ul id="patterns_listing">
   
 		<li>
+		  <a href="/patterns/Asynchronous-notice">
+			  <h3>
+		  		
+						Asynchronous notice
+					
+				</h3>
+
+				
+					<p>How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p>
+				
+			</a>
+		</li>
+  
+		<li>
+		  <a href="/patterns/Encryption-user-managed-keys">
+			  <h3>
+		  		
+						Encryption with user-managed keys
+					
+				</h3>
+
+				
+					<p>Use encryption in such a way that the service provider cannot decrypt the user&#39;s information because the user manages the keys.</p>
+				
+			</a>
+		</li>
+  
+		<li>
 		  <a href="/patterns/Active-broadcast-of-presence">
 			  <h3>
 		  		
@@ -118,20 +146,6 @@
 
 				
 					<p>Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p>
-				
-			</a>
-		</li>
-  
-		<li>
-		  <a href="/patterns/Asynchronous-notice">
-			  <h3>
-		  		
-						Asynchronous notice
-					
-				</h3>
-
-				
-					<p>How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p>
 				
 			</a>
 		</li>

--- a/site/deploy/categories/notice/index.html
+++ b/site/deploy/categories/notice/index.html
@@ -95,15 +95,15 @@
   <ul id="patterns_listing">
   
 		<li>
-		  <a href="/patterns/Ambient-notice">
+		  <a href="/patterns/Unusual-activities">
 			  <h3>
 		  		
-						Ambient notice
+						Handling unusual account activities with multiple factors
 					
 				</h3>
 
 				
-					<p>Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p>
+					<p>Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.</p>
 				
 			</a>
 		</li>
@@ -118,6 +118,20 @@
 
 				
 					<p>How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p>
+				
+			</a>
+		</li>
+  
+		<li>
+		  <a href="/patterns/Ambient-notice">
+			  <h3>
+		  		
+						Ambient notice
+					
+				</h3>
+
+				
+					<p>Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p>
 				
 			</a>
 		</li>

--- a/site/deploy/index.html
+++ b/site/deploy/index.html
@@ -87,21 +87,10 @@
 		
 		  
   			<li>
-  				<a href='/patterns/Active-broadcast-of-presence'>
-  				  <h3>Active broadcast of presence</h3>
+  				<a href='/patterns/Location-granularity'>
+  				  <h3>Location Granularity</h3>
   					
-  						<p>Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p>
-  					
-  				</a>
-  			</li>
-			
-		
-		  
-  			<li>
-  				<a href='/patterns/Ambient-notice'>
-  				  <h3>Ambient notice</h3>
-  					
-  						<p>Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p>
+  						<p>Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p>
   					
   				</a>
   			</li>
@@ -109,10 +98,19 @@
 		
 		  
   			<li>
-  				<a href='/patterns/Asynchronous-notice'>
-  				  <h3>Asynchronous notice</h3>
+  				<a href='/patterns/Private-link'>
+  				  <h3>Private link</h3>
   					
-  						<p>How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p>
+  				</a>
+  			</li>
+			
+		
+		  
+  			<li>
+  				<a href='/patterns/Privacy-dashboard'>
+  				  <h3>Privacy dashboard</h3>
+  					
+  						<p>An informational privacy dashboard can provide collected summaries of the collected or processed personal data for a particular user.</p>
   					
   				</a>
   			</li>

--- a/site/deploy/patterns/Active-broadcast-of-presence.html
+++ b/site/deploy/patterns/Active-broadcast-of-presence.html
@@ -104,9 +104,15 @@
         
       
         
+      
+        
           
 <a href="/categories/location" class="location">location</a>
            &bull; 
+        
+      
+        
+      
         
       
         
@@ -145,6 +151,12 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
       
         
@@ -159,6 +171,12 @@
           
 <a href="/categories/mobile" class="mobile">mobile</a>
           
+        
+      
+        
+      
+        
+      
         
       
         
@@ -224,7 +242,7 @@
   <script type="text/javascript">
       /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
       var disqus_shortname = 'privacypatterns';
-      var disqus_developer = 1; // Remove this when going live
+      // var disqus_developer = 1; // Remove this when going live
 
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {

--- a/site/deploy/patterns/Asynchronous-notice.html
+++ b/site/deploy/patterns/Asynchronous-notice.html
@@ -104,9 +104,15 @@
         
       
         
+      
+        
           
 <a href="/categories/location" class="location">location</a>
            &bull; 
+        
+      
+        
+      
         
       
         
@@ -145,6 +151,12 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
       
         
@@ -159,6 +171,12 @@
           
 <a href="/categories/mobile" class="mobile">mobile</a>
           
+        
+      
+        
+      
+        
+      
         
       
         
@@ -239,11 +257,15 @@ like the Location History&nbsp;service.</p>
 <hr />
 <pre><code> This is a reminder that you are sharing your Latitude location with the following application(s):
 
+
+
  Google Location History 
  You may disable these applications at any time by going to &lt;https://www.google.com/latitude/apps?hl=en]&gt;
 
  **Do more with Latitude**
  Go to &lt;https://www.google.com/latitude/apps&gt; on your computer and try the following:
+
+
 
  Google Location History lets you store your history and see a dashboard of interesting information such as frequently visited places and recent trips. 
  Google Talk Location Status lets you post your location in your chat status. 
@@ -285,7 +307,7 @@ concerns of an attacker's opting the user in without their&nbsp;knowledge.</p>
   <script type="text/javascript">
       /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
       var disqus_shortname = 'privacypatterns';
-      var disqus_developer = 1; // Remove this when going live
+      // var disqus_developer = 1; // Remove this when going live
 
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {

--- a/site/deploy/patterns/Encryption-user-managed-keys.html
+++ b/site/deploy/patterns/Encryption-user-managed-keys.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>
 		
-		Ambient notice - Privacy Patterns
+		Encryption with user-managed keys - Privacy Patterns
 		
 	</title>
   <meta name="description" content="Privacy patterns in software design">
@@ -26,7 +26,7 @@
   <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 </head>
-	<body id="ambient-notice">
+	<body id="encryption-with-user-managed-keys">
     <div id="container">
 
 			<header>
@@ -106,13 +106,13 @@
         
       
         
+      
+        
+      
+        
           
-<a href="/categories/location" class="location">location</a>
+<a href="/categories/encryption" class="encryption">encryption</a>
            &bull; 
-        
-      
-        
-      
         
       
         
@@ -124,11 +124,11 @@
     
       
         
-      
-        
           
-<a href="/categories/notice" class="notice">notice</a>
+<a href="/categories/control" class="control">control</a>
            &bull; 
+        
+      
         
       
         
@@ -212,19 +212,19 @@
         
       
         
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
           
-<a href="/categories/ui" class="ui">ui</a>
+<a href="/categories/cloud" class="cloud">cloud</a>
           
-        
-      
-        
-      
-        
-      
-        
-      
-        
-      
         
       
         
@@ -233,7 +233,7 @@
   </p>
   <h1>
 		
-			Ambient notice
+			Encryption with user-managed keys
 		
 	</h1>
 	
@@ -243,40 +243,38 @@
 <li><a href="#context">Context</a></li>
 <li><a href="#problem">Problem</a></li>
 <li><a href="#solution">Solution</a><ul>
-<li><a href="#examples">Examples</a><ul>
-<li><a href="#location-services-icons-mac-os-x-google-chrome-et-al">Location services icons: Mac OS X, Google Chrome, et&nbsp;al.</a></li>
-</ul>
-</li>
+<li><a href="#examples">Examples</a></li>
 </ul>
 </li>
 <li><a href="#forcesconcerns">Forces/Concerns</a></li>
 </ul>
 </div>
 <h2 id="intent"><a class="toclink" href="#intent">Intent</a></h2>
-<p>Provide unobtrusive, ongoing notice of real-time location&nbsp;tracking.</p>
-<p>Supports <a href="Notice">notice</a>, <a href="Transparency-and-feedback">transparency</a> and <a href="User-control">user control</a>.</p>
+<p>Enable encryption, with user-managed encryption keys, to protect the confidentiality of personal information that may be transferred or stored by an untrusted 3rd&nbsp;party.</p>
+<p>Supports <a href="User-control">user control</a>, <a href="Cloud Computing">cloud computing</a> and <a href="Mobile">mobile</a>.</p>
 <h2 id="context"><a class="toclink" href="#context">Context</a></h2>
-<p>When a service is tracking a user's location in an ongoing fashion, or accessing the user's location on each repeated use of a service. (See also, <a href="Asynchronous-notice">asynchronous notice</a>.)</p>
+<p>User wants to store or transfer their personal data through an online service and they want to protect their privacy, and specifically the confidentiality of their personal information. Risks of unauthorized access may include the online service provider itself, or third parties such as its partners for example for backup, or government surveillance depending on the geographies the data is stored in or transferred&nbsp;through. </p>
 <h2 id="problem"><a class="toclink" href="#problem">Problem</a></h2>
-<p>How can a service effectively provide notice to a user that location tracking is continuing, or happening again, without being as obtrusive as a repeated modal dialog? A user may not realize that an application given permission to access location is doing so continuously or repeatedly, or may not remember that explicit permissions given in the past allow a service to access data again later. In some cases, past explicit permission may not have been provided by the current user of the device (but instead by a spouse, parent or even an ex-spouse or stalker who temporarily had control of the device or the account). If notice is provided only at the time of consent, a user may inadvertently distribute personal information over a long period of time after having lost control of their device only&nbsp;momentarily.</p>
+<p>How can a user store or transfer their personal information through an online service while ensuring their privacy and specifically preventing unauthorized access to their personal&nbsp;information?</p>
 <h2 id="solution"><a class="toclink" href="#solution">Solution</a></h2>
-<p>Provide an <em>ambient</em> notice &mdash; unobtrusive, non-modal, but available at a glance or from a simple action &mdash; when location data is being accessed. The notice should provide opportunities for interaction: to learn more about the use of data or to revoke&nbsp;permissions.</p>
+<p>Encryption of the personal information of the user prior to storing it with, or transferring it through an online service. In this solution the user shall generate a strong encryption key and manage it themselves, specifically keeping it private and unknown to the untrusted online service or 3rd&nbsp;parties.</p>
 <h3 id="examples"><a class="toclink" href="#examples">Examples</a></h3>
-<h4 id="location-services-icons-mac-os-x-google-chrome-et-al"><a class="toclink" href="#location-services-icons-mac-os-x-google-chrome-et-al">Location services icons: Mac OS X, Google Chrome, et&nbsp;al.</a></h4>
-<p><img alt="Lion Location Icon" src="/media/images/lion_location_icon.png" /></p>
-<p>Mac OS X Lion adds an ambient location services icon (a compass arrow) which appears in the task bar momentarily when an application is accessing the device's&nbsp;location.</p>
-<p><img alt="Chrome Location Icon" src="/media/images/chrome_location_icon.png" /></p>
-<p>Chrome adds a cross-hair icon to the location bar when a web site accesses the device location via the W3C Geolocation API. Clicking on the icon provides potential actions: clearing the saved consent for this site and accessing&nbsp;settings.</p>
-<p><em>Similar examples exist in at least Android, iOS and&nbsp;Win7.</em></p>
+<ul>
+<li><a href="https://spideroak.com/">Spider Oak</a>: online backup, sync, sharing enabling user managed personal information in zero knowledge privacy&nbsp;environment.</li>
+<li><a href="https://leastauthority.com/">Least Authority</a>: secure offsite backup system with client side&nbsp;encryption.</li>
+<li><a href="https://lastpass.com/">LastPass</a>: encrypted credentials and personal information database with user managed encryption&nbsp;keys.</li>
+</ul>
+<p><a href="http://zeroknowledgeprivacy.org/">Some</a> have used the term "zero-knowledge" to describe this pattern; however, "zero-knowledge proof" is a cryptographic term with a <a href="https://en.wikipedia.org/wiki/Zero-knowledge_proof">distinct meaning</a>.</p>
 <h2 id="forcesconcerns"><a class="toclink" href="#forcesconcerns">Forces/Concerns</a></h2>
-<p>A tray full of ambient notices may annoy or confuse users and inure them to ongoing practices. Take measures to avoid unnecessary notice. This must be balanced against the
-concerns of an attacker's opting the user in without their&nbsp;knowledge.</p>
+<p>Requiring the user to do encryption key management may annoy or confuse them and they may revert to either no encryption, or encryption with the online service provider managing the encryption key (affording no protection from the specific online service provider managing the key), picking an encryption key that is weak, reused, written down and so&nbsp;forth. </p>
+<p>Some metadata may need to remain unencrypted to support the online service provider or 3rd party functions, for example file names for cloud storage, or routing information for transfer applications, exposing the metadata to risks of unauthorized access, server side indexing for searching, or&nbsp;de-duplication. </p>
+<p>If the service provider has written the client side software that does the client side encryption with a user-managed encryption key, there can be additional concerns regarding whether the client software is secure or tampered with in ways that can compromise&nbsp;privacy.</p>
 
 	
 	
   <p id="comments_link">
     Questions or comments? Email Nick Doty at <a href="mailto:npdoty@ischool.berkeley.edu" title="Email Nick Doty">npdoty@ischool.berkeley.edu</a>.
-    <br />Corrections or additions? <a href="https://github.com/m0hit/privacypatterns/wiki/Ambient-notice" target="_blank">Contribute via Github!</a>
+    <br />Corrections or additions? <a href="https://github.com/m0hit/privacypatterns/wiki/Encryption-user-managed-keys" target="_blank">Contribute via Github!</a>
   </p>
   
 

--- a/site/deploy/patterns/Encryption-user-managed-keys.md
+++ b/site/deploy/patterns/Encryption-user-managed-keys.md
@@ -1,0 +1,31 @@
+[TOC]
+
+##Intent##
+Enable encryption, with user-managed encryption keys, to protect the confidentiality of personal information that may be transferred or stored by an untrusted 3rd party.
+
+Supports [user control](User-control), [cloud computing](Cloud Computing) and [mobile](Mobile).
+
+##Context##
+User wants to store or transfer their personal data through an online service and they want to protect their privacy, and specifically the confidentiality of their personal information. Risks of unauthorized access may include the online service provider itself, or third parties such as its partners for example for backup, or government surveillance depending on the geographies the data is stored in or transferred through. 
+
+##Problem##
+How can a user store or transfer their personal information through an online service while ensuring their privacy and specifically preventing unauthorized access to their personal information?
+
+##Solution##
+Encryption of the personal information of the user prior to storing it with, or transferring it through an online service. In this solution the user shall generate a strong encryption key and manage it themselves, specifically keeping it private and unknown to the untrusted online service or 3rd parties.
+
+###Examples###
+
+* [Spider Oak](https://spideroak.com/): online backup, sync, sharing enabling user managed personal information in zero knowledge privacy environment.
+* [Least Authority](https://leastauthority.com/): secure offsite backup system with client side encryption.
+* [LastPass](https://lastpass.com/): encrypted credentials and personal information database with user managed encryption keys.
+
+[Some](http://zeroknowledgeprivacy.org/) have used the term "zero-knowledge" to describe this pattern; however, "zero-knowledge proof" is a cryptographic term with a [distinct meaning](https://en.wikipedia.org/wiki/Zero-knowledge_proof).
+
+##Forces/Concerns##
+
+Requiring the user to do encryption key management may annoy or confuse them and they may revert to either no encryption, or encryption with the online service provider managing the encryption key (affording no protection from the specific online service provider managing the key), picking an encryption key that is weak, reused, written down and so forth. 
+
+Some metadata may need to remain unencrypted to support the online service provider or 3rd party functions, for example file names for cloud storage, or routing information for transfer applications, exposing the metadata to risks of unauthorized access, server side indexing for searching, or de-duplication. 
+
+If the service provider has written the client side software that does the client side encryption with a user-managed encryption key, there can be additional concerns regarding whether the client software is secure or tampered with in ways that can compromise privacy.

--- a/site/deploy/patterns/Location-granularity.html
+++ b/site/deploy/patterns/Location-granularity.html
@@ -104,9 +104,15 @@
         
       
         
+      
+        
           
 <a href="/categories/location" class="location">location</a>
            &bull; 
+        
+      
+        
+      
         
       
         
@@ -127,6 +133,12 @@
           
 <a href="/categories/minimization" class="minimization">minimization</a>
           
+        
+      
+        
+      
+        
+      
         
       
         
@@ -200,8 +212,7 @@
 <h4 id="geode"><a class="toclink" href="#geode">Geode</a></h4>
 <p>One of the fore-runners to the W3C Geolocation API, Firefox's experimental Geode feature allowed JavaScript access to the current location at four different levels of&nbsp;granularity.</p>
 <h2 id="forcesconcerns"><a class="toclink" href="#forcesconcerns">Forces/Concerns</a></h2>
-<p>Accepting or transmitting location data at different levels of granularity generally requires a location hierarchy or geographic ontology agreed upon by both services and a more complex data storage model than simple digital coordinates.<br />
-</p>
+<p>Accepting or transmitting location data at different levels of granularity generally requires a location hierarchy or geographic ontology agreed upon by both services and a more complex data storage model than simple digital&nbsp;coordinates.  </p>
 <p>Truncating latitude and longitude coordinates to a certain number of decimal places may decrease precision, but is generally not considered a good fuzzing algorithm. (For example, if a user is moving in a straight line and regularly updating their location, truncated location information will occasionally reveal precise location when the user crosses a lat/lon boundary.) Similarly, using "town" rather than lat/lon may occasionally reveal more precise data than expected when the user crosses a border between two&nbsp;towns.</p>
 
 	
@@ -216,7 +227,7 @@
   <script type="text/javascript">
       /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
       var disqus_shortname = 'privacypatterns';
-      var disqus_developer = 1; // Remove this when going live
+      // var disqus_developer = 1; // Remove this when going live
 
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {

--- a/site/deploy/patterns/Privacy-dashboard.html
+++ b/site/deploy/patterns/Privacy-dashboard.html
@@ -106,9 +106,15 @@
         
       
         
+      
+        
           
 <a href="/categories/transparency" class="transparency">transparency</a>
            &bull; 
+        
+      
+        
+      
         
       
         
@@ -145,7 +151,15 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
+      
+        
       
         
       
@@ -167,6 +181,10 @@
           
 <a href="/categories/location" class="location">location</a>
           
+        
+      
+        
+      
         
       
         
@@ -232,7 +250,7 @@
   <script type="text/javascript">
       /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
       var disqus_shortname = 'privacypatterns';
-      var disqus_developer = 1; // Remove this when going live
+      // var disqus_developer = 1; // Remove this when going live
 
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {

--- a/site/deploy/patterns/Private-link.html
+++ b/site/deploy/patterns/Private-link.html
@@ -115,7 +115,17 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
+      
+        
+      
+        
       
         
       
@@ -145,6 +155,8 @@
       
         
       
+        
+      
     
       
         
@@ -161,6 +173,12 @@
           
 <a href="/categories/media" class="media">media</a>
            &bull; 
+        
+      
+        
+      
+        
+      
         
       
         
@@ -205,6 +223,12 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
   </p>
   <h1>
@@ -223,6 +247,7 @@
 <li><a href="#flickr-guest-pass">Flickr "Guest&nbsp;Pass"</a></li>
 <li><a href="#google-anyone-with-the-link-sharing">Google "anyone with the link"&nbsp;sharing</a></li>
 <li><a href="#tripit-get-a-link">Tripit "Get a&nbsp;link"</a></li>
+<li><a href="#dropbox-share-link">Dropbox "Share&nbsp;Link"</a></li>
 </ul>
 </li>
 </ul>
@@ -236,6 +261,8 @@
 <h2 id="context"><a class="toclink" href="#context">Context</a></h2>
 <p>When private content is accessible online, especially granular resources, and users want to share (and enable re-sharing) using existing communication mechanisms. Also particularly relevant when users are sharing with contacts who can't easily&nbsp;authenticate.</p>
 <h2 id="problem"><a class="toclink" href="#problem">Problem</a></h2>
+<p>How do you share a private resource with unauthenticated users in a way that respects its sensitivity?
+The solution must not allow unauthenticated users to access resources that weren't intended to be&nbsp;shared. </p>
 <h2 id="solution"><a class="toclink" href="#solution">Solution</a></h2>
 <p>Provide the user a <em>private link</em> or <em>unguessable URL</em> for a particular set of their personal information (their current location, an album of photos). Anyone who has the link may access the information, but the link is not posted publicly or easily guessable by an outsider, so the information is not shared with all. The user can share the private link with friends, family or other trusted contacts who can in turn forward the link to others who will be able to access it, without any account authentication or access control&nbsp;lists.</p>
 <p>Services may also allow users to revoke existing private links or change the URL to effectively re-set who can access the&nbsp;resource.</p>
@@ -243,6 +270,7 @@
 <h4 id="flickr-guest-pass"><a class="toclink" href="#flickr-guest-pass">Flickr "Guest&nbsp;Pass"</a></h4>
 <h4 id="google-anyone-with-the-link-sharing"><a class="toclink" href="#google-anyone-with-the-link-sharing">Google "anyone with the link"&nbsp;sharing</a></h4>
 <h4 id="tripit-get-a-link"><a class="toclink" href="#tripit-get-a-link">Tripit "Get a&nbsp;link"</a></h4>
+<h4 id="dropbox-share-link"><a class="toclink" href="#dropbox-share-link">Dropbox "Share&nbsp;Link"</a></h4>
 <h2 id="forcesconcerns"><a class="toclink" href="#forcesconcerns">Forces/Concerns</a></h2>
 <p>Be sure the link is unguessable (within some bounds) so that an outsider can't easily find all (or any) of the unlisted links either by brute force or by knowing when information was stored or what its name might&nbsp;be.</p>
 <p>Note that the URL will be retained in recipients' browser history and could easily be inadvertently shared with others. Services should help users understand these&nbsp;limitations.</p>
@@ -259,7 +287,7 @@
   <script type="text/javascript">
       /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
       var disqus_shortname = 'privacypatterns';
-      var disqus_developer = 1; // Remove this when going live
+      // var disqus_developer = 1; // Remove this when going live
 
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {

--- a/site/deploy/patterns/Private-link.md
+++ b/site/deploy/patterns/Private-link.md
@@ -10,6 +10,9 @@ When private content is accessible online, especially granular resources, and us
 
 ##Problem##
 
+How do you share a private resource with unauthenticated users in a way that respects its sensitivity?
+The solution must not allow unauthenticated users to access resources that weren't intended to be shared. 
+
 ##Solution##
 
 Provide the user a _private link_ or _unguessable URL_ for a particular set of their personal information (their current location, an album of photos). Anyone who has the link may access the information, but the link is not posted publicly or easily guessable by an outsider, so the information is not shared with all. The user can share the private link with friends, family or other trusted contacts who can in turn forward the link to others who will be able to access it, without any account authentication or access control lists.
@@ -23,6 +26,8 @@ Services may also allow users to revoke existing private links or change the URL
 #### Google "anyone with the link" sharing ####
 
 #### Tripit "Get a link" ####
+
+#### Dropbox "Share Link" ####
 
 ##Forces/Concerns##
 

--- a/site/deploy/patterns/Strip-invisible-metadata.html
+++ b/site/deploy/patterns/Strip-invisible-metadata.html
@@ -110,6 +110,12 @@
         
       
         
+      
+        
+      
+        
+      
+        
           
 <a href="/categories/metadata" class="metadata">metadata</a>
            &bull; 
@@ -127,6 +133,12 @@
           
 <a href="/categories/minimization" class="minimization">minimization</a>
            &bull; 
+        
+      
+        
+      
+        
+      
         
       
         
@@ -175,7 +187,15 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
+      
+        
       
         
       
@@ -197,6 +217,10 @@
           
 <a href="/categories/location" class="location">location</a>
            &bull; 
+        
+      
+        
+      
         
       
         
@@ -235,6 +259,12 @@
       
         
       
+        
+      
+        
+      
+        
+      
     
   </p>
   <h1>
@@ -250,10 +280,8 @@
 <li><a href="#problem">Problem</a></li>
 <li><a href="#solution">Solution</a></li>
 <li><a href="#examples">Examples</a><ul>
-<li><a href="#uploading-images-to-twittercom">Uploading images to twitter.com</a><ul>
+<li><a href="#uploading-images-to-twittercom">Uploading images to&nbsp;twitter.com</a></li>
 <li><a href="#hiding-exif-data-on-flickrcom">Hiding EXIF data on&nbsp;Flickr.com</a></li>
-</ul>
-</li>
 </ul>
 </li>
 </ul>
@@ -317,7 +345,7 @@ whether they are sharing location as part of uploading their&nbsp;images. </p>
   <script type="text/javascript">
       /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
       var disqus_shortname = 'privacypatterns';
-      var disqus_developer = 1; // Remove this when going live
+      // var disqus_developer = 1; // Remove this when going live
 
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {

--- a/site/deploy/patterns/Unusual-activities.html
+++ b/site/deploy/patterns/Unusual-activities.html
@@ -1,0 +1,488 @@
+
+
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>
+		
+		Handling unusual account activities with multiple factors - Privacy Patterns
+		
+	</title>
+  <meta name="description" content="Privacy patterns in software design">
+  <meta name="author" content="Nick Doty and Mohit Gupta">
+  <link rel="shortcut icon" href="/media/images/favicon.ico">
+  
+	
+  <!-- CSS: implied media="all" -->
+  <link href='http://fonts.googleapis.com/css?family=Lora:400,700' rel='stylesheet' type='text/css'>
+  <link href="http://fonts.googleapis.com/css?family=Cuprum:regular&v1" rel="stylesheet" type="text/css" >
+  <link href="http://fonts.googleapis.com/css?family=News+Cycle&subset=latin&v2" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="/media/css/main.css?v=2">
+	
+	
+	
+	<!--[if lt IE 9]>
+  <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
+</head>
+	<body id="handling-unusual-account-activities-with-multiple-factors">
+    <div id="container">
+
+			<header>
+  <div id="logo"><a href="/" title="Home">privacy<span class="highlight">patterns</span>.org</a></div>
+  
+  
+<nav>
+  <ul>
+    <li><a href="/">Home</a> &bull; </li>
+    <li><a href="/about/">About</a> &bull; </li>
+    <li><a href="/patterns/">Patterns</a></li>
+  </ul>
+</nav>
+
+  
+</header>
+  
+<!-- 
+
+
+
+<ul class="breadcrumbs">
+	
+		<li>
+			<a href="/">Privacy Patterns</a>
+
+			
+				
+				<span class="separator">&gt;</span>
+				
+			
+		</li>
+	
+		<li>
+			<a href="/patterns">Patterns</a>
+
+			
+		</li>
+	
+</ul>
+    
+
+
+
+
+ -->
+
+
+      <div id="main" role="main">
+			  
+
+
+
+
+
+
+<div id="content">
+  <p id="cats">
+    Categories: 
+      
+        
+          
+<a href="/categories/control" class="control">control</a>
+           &bull; 
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    
+      
+        
+      
+        
+          
+<a href="/categories/notice" class="notice">notice</a>
+           &bull; 
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+          
+<a href="/categories/authentication" class="authentication">authentication</a>
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    
+  </p>
+  <h1>
+		
+			Handling unusual account activities with multiple factors
+		
+	</h1>
+	
+
+	<div class="toc"><span class="toctitle">Contents</span><ul>
+<li><a href="#intent">Intent</a></li>
+<li><a href="#context">Context</a></li>
+<li><a href="#problem">Problem</a></li>
+<li><a href="#solutions">Solutions</a><ul>
+<li><a href="#identify-unusual-activities">Identify Unusual Activities</a><ul>
+<li><a href="#a-website">A&nbsp;Website</a></li>
+<li><a href="#an-application">An&nbsp;Application</a></li>
+</ul>
+</li>
+<li><a href="#require-multi-factor-authentication">Require Multi-factor&nbsp;Authentication</a></li>
+<li><a href="#notify-account-holders-of-unusual-activities">Notify Account Holders of Unusual&nbsp;Activities</a></li>
+</ul>
+</li>
+<li><a href="#examples">Examples</a><ul>
+<li><a href="#gmail">Gmail</a></li>
+<li><a href="#facebook">Facebook</a></li>
+<li><a href="#dropbox">Dropbox</a></li>
+</ul>
+</li>
+<li><a href="#forcesconcerns">Forces/Concerns</a></li>
+<li><a href="#reflection-on-the-process">Reflection on the Process</a><ul>
+<li><a href="#determining-the-scope">Determining the&nbsp;Scope</a></li>
+<li><a href="#relevant-information">Relevant&nbsp;Information</a></li>
+<li><a href="#limitations-and-discussion">Limitations and&nbsp;Discussion</a></li>
+</ul>
+</li>
+<li><a href="#references">References</a></li>
+</ul>
+</div>
+<h2 id="intent"><a class="toclink" href="#intent">Intent</a></h2>
+<p>For Internet services, prevent suspicious access to the account, and/or
+make the account owner aware of unusual&nbsp;activities.</p>
+<h2 id="context"><a class="toclink" href="#context">Context</a></h2>
+<p>Many Internet services are using password-based authentication which is
+really convenient (compared to strong authentication) but has apparent&nbsp;drawbacks:</p>
+<ul>
+<li>
+<p>The password itself does not&nbsp;change.</p>
+<p>Unless the account owner changes the password, all sign-ins use the
+same identity-password combination. If the password is stolen by a
+malicious party through some means, it can be reused until it is&nbsp;changed.</p>
+</li>
+<li>
+<p>The password can be&nbsp;cracked.</p>
+<p>Many account owners tend to use weak passwords that can be
+brute-force attacked online. Sometimes the hacker can obtain the
+database dump which contains hashed passwords, which can be
+brute-forced&nbsp;offline.</p>
+</li>
+<li>
+<p>The account owner has no way to ensure their exclusive possession of
+    the&nbsp;password.</p>
+<p>The account owner has no evidence if the password is stolen by a
+malicious&nbsp;party.</p>
+</li>
+<li>
+<p>The only way to control who can access is to reset the&nbsp;password.</p>
+<p>As a result, if the account owner want to ensure only they have the
+password, they can only reset the password. In some scenarios,
+resetting the password is not&nbsp;enough.</p>
+</li>
+<li>
+<p>The password can be seen by people&nbsp;around.</p>
+<p>When the account owner enters the password on a computer keyboard or
+the screen of a mobile device (mobile phone / tablet), people around
+have the ability to snoop the password and record&nbsp;it.</p>
+</li>
+</ul>
+<p>Thus, a service can't tell if the user is legitimate even if the
+identity-password combination provided by the user is correct.
+Fortunately, a service can usually receive some meta information to help
+determine if an activity is unusual. In case of such unusual activities,
+a service needs to prevent suspicious access to an account, and/or
+inform the account owner of the unusual&nbsp;activities.</p>
+<h2 id="problem"><a class="toclink" href="#problem">Problem</a></h2>
+<p>How can a service that uses username-password authentication and
+involves a lot of privacy identify unusual sign-ins, confirm the
+identify of the user, and inform the account owner of such unusual&nbsp;activities?</p>
+<h2 id="solutions"><a class="toclink" href="#solutions">Solutions</a></h2>
+<p>First, the service should be able to identify unusual sign-ins Then the
+service may use multi-factor authentication to confirm the identity of
+the&nbsp;user.</p>
+<p>The user should be informed of unusual activites, or have some ways to
+see recent events, and even do&nbsp;something.</p>
+<h3 id="identify-unusual-activities"><a class="toclink" href="#identify-unusual-activities">Identify Unusual&nbsp;Activities</a></h3>
+<p>Today, a web service may appear as a website or an application on the
+user's devices (including mobile devices and the PCs). The service can
+use meta information to determine if a sign-in with the correct
+username-password combination is&nbsp;suspicious.</p>
+<p>The strategies described here has both false positives and false&nbsp;negatives.</p>
+<h4 id="a-website"><a class="toclink" href="#a-website">A&nbsp;Website</a></h4>
+<p>Typically, a sign-in to a website is in the form of an HTTP request,
+which contains many customized settings of the browser, including the
+type of the browser and operating system as well as the architecture
+(<code>User-Agent</code> header), the Cookie (<code>Cookie</code> header), language
+preferences (<code>Accept-Languages</code> header). Apart from these, the website
+can get the IP address of the user, which may be mapped to a certain
+country/area through&nbsp;GeoIP.</p>
+<p>The above meta information can be used to tell if a browser is <em>new</em> to
+the website. The website can have its rules to determine if an access is
+<em>suspicious</em>, for example, an access from a new country / browser /
+operating system is considered&nbsp;suspicious.</p>
+<h4 id="an-application"><a class="toclink" href="#an-application">An&nbsp;Application</a></h4>
+<p>By running native code, the application can collect some identifiers of
+the machine, including the operating system environment settings (e.g.
+the list of running processes), the hardware parameters (such as the ID
+of the CPU), and device UUIDs (provided by mobile operating systems like
+iOS). By completing a network request, the service also retrieves the IP
+address of the&nbsp;machine.</p>
+<p>The above meta information can be used to tell if a machine is <em>new</em> to
+the service. The service can have its rules to determine if a sign-in is
+<em>suspicious</em>, for example, an access from a new country / machine /
+operating system is considered&nbsp;suspicious.</p>
+<h3 id="require-multi-factor-authentication"><a class="toclink" href="#require-multi-factor-authentication">Require Multi-factor&nbsp;Authentication</a></h3>
+<p>In case of a suspicious sign-in, multi-factor authentication may be a
+way to let the legitimate user in. The service can request one more
+authentication except password, such&nbsp;as:</p>
+<ul>
+<li>
+<p>A software&nbsp;token</p>
+<p>Examples include Google Authenticator which runs on mobile phones
+and implements RFC6238 TOTP security&nbsp;tokens..</p>
+</li>
+<li>
+<p>A hardware token&nbsp;(disconnected)</p>
+<p>Examples include a token issued by a bank which displays digits,
+which is similar to a software&nbsp;token.</p>
+</li>
+<li>
+<p>A hardware token&nbsp;(connected)</p>
+<p>The token may exchange a longer secondary password than the previous
+one, which means it's&nbsp;safer.</p>
+</li>
+<li>
+<p>Personal data like date of birth,&nbsp;SSN</p>
+<p>Obviously not a good choice here because it cannot be&nbsp;changed.</p>
+</li>
+<li>
+<p>An one-time password (OTP) sent to the registered E-mail address /
+    mobile&nbsp;phone</p>
+<p>Depending the type of the service, maybe the user uses the same
+password for the E-mail address, or maybe the mobile phone is stolen
+and the service runs on the mobile&nbsp;phone.</p>
+</li>
+</ul>
+<p>Using multi-factor authentication only in case of suspicious sign-ins is
+more convenient to using it all the time, but is less&nbsp;secure.</p>
+<h3 id="notify-account-holders-of-unusual-activities"><a class="toclink" href="#notify-account-holders-of-unusual-activities">Notify Account Holders of Unusual&nbsp;Activities</a></h3>
+<p>When an suspicious sign-in is detected, it may be a sign that the
+password has already been leaked. Depending on the type of the service,
+it can notify the user about the suspicious sign-in through E-mail,
+telephone, or other&nbsp;means.</p>
+<p>Here the immediate notification can also be used in the multi-factor&nbsp;authentication.</p>
+<p>For services that can be logged on from multiple devices at the same
+time, the user should be able to check the existence of other sessions,
+and review recent sign-in&nbsp;events.</p>
+<h2 id="examples"><a class="toclink" href="#examples">Examples</a></h2>
+<h3 id="gmail"><a class="toclink" href="#gmail">Gmail</a></h3>
+<p>Gmail displays information about other sessions (if any) in the footer,
+linking to a page named "Activity on this account" which lists other
+sessions and recent activities to the Gmail account. The user has the
+option to sign out other&nbsp;sessions.</p>
+<p>In case of annoying false positives, the user may choose to disable the
+alert for unusual activity. The disable takes about a week, "to make
+sure the bad guys aren't the ones who turned off your&nbsp;alerts."</p>
+<h3 id="facebook"><a class="toclink" href="#facebook">Facebook</a></h3>
+<p>When Facebook detects an unusual sign-in, it shows <em>social
+authentication</em> that displays a few pictures of the user's friends and
+asks the user to name the person in those&nbsp;photos.</p>
+<h3 id="dropbox"><a class="toclink" href="#dropbox">Dropbox</a></h3>
+<p>The <em>Security</em> tab of the <em>Settings</em> of the Dropbox website displays all
+web browser sessions logged in to the account, and enables the user to
+log out one or more of them. The name of the browser, operating system,
+and the IP address and corresponding country are displayed to help the
+user make a&nbsp;choice.</p>
+<p>It also displays all devices that are linked to the account, and allows
+the user to unlink one or more of&nbsp;them.</p>
+<h2 id="forcesconcerns"><a class="toclink" href="#forcesconcerns">Forces/Concerns</a></h2>
+<p>The pattern described here is a tradeoff between pure password
+authentication which is insecure, and pure multi-factor authentication
+which is inconvenient. It increases privacy at the cost of&nbsp;usability.</p>
+<p>The fallback multi-factor authentication should be picked carefully with
+the understanding of the&nbsp;service.</p>
+<ul>
+<li>In the above example, Facebook makes use of its resource of
+    friendship and photos. Their decision is based on the assumption
+    that it is very unlikely for a hacker to recognize the friends.
+    Actually the assumption may not hold true in some scenarios, because
+    many of the photos are public and can be viewed under another
+    account, or can be identified with the help from a large-scale
+    tagged photo collection and machine&nbsp;learning.</li>
+<li>Persuading the user into carrying a hardware token everywhere only
+    for occasional multi-factor authentication may be difficult, but it
+    might worth the effort for financial&nbsp;services.</li>
+</ul>
+<p>The strategy to identify unusual activities should also be considered
+seriously. It should be also to identify most of the activities, with a
+false positive rate that is not too high. It should balance the cost of
+multi-factor&nbsp;authentication.</p>
+<h2 id="reflection-on-the-process"><a class="toclink" href="#reflection-on-the-process">Reflection on the&nbsp;Process</a></h2>
+<h3 id="determining-the-scope"><a class="toclink" href="#determining-the-scope">Determining the&nbsp;Scope</a></h3>
+<p>I started with Gmail's display of account activities. It displays
+unusual activities regarding an account, which involves identifying
+unusual activities where the password entered is correct. For some other
+services, correct passwords can be rejected from a new device /&nbsp;location.</p>
+<p>So, the scope of this pattern is to handle unusual activities (including&nbsp;sign-ins).</p>
+<h3 id="relevant-information"><a class="toclink" href="#relevant-information">Relevant&nbsp;Information</a></h3>
+<p>This pattern includes multi-factor authentication and two-step
+authentication, which are well studied. But the general topic about
+informing the user of unusual activites seems to be lack of&nbsp;literature.</p>
+<h3 id="limitations-and-discussion"><a class="toclink" href="#limitations-and-discussion">Limitations and&nbsp;Discussion</a></h3>
+<p>This pattern has some limitations. For example, it relies on accurate
+identification of suspicious sign-ins based on meta information, where
+the meta information including the IP address can be spoofed by an
+experienced&nbsp;attacker.</p>
+<p>If the fallback multi-factor authentication only happens occationally to
+the legitimate account owner, they may be unprepared to such
+authentication, leading to a decreased&nbsp;usability.</p>
+<h2 id="references"><a class="toclink" href="#references">References</a></h2>
+<ul>
+<li>Polakis, I., Lancini, M., Kontaxis, G., Maggi, F., Ioannidis, S.,
+    Keromytis, A. D., <span class="amp">&amp;</span> Zanero, S. (2012, December). <strong>All Your Face are
+    Belong to Us: Breaking Facebook's Social Authentication</strong>. In
+    <em>Proceedings of the 28th Annual Computer Security Applications
+    Conference</em> (pp. 399-408).&nbsp;ACM.</li>
+</ul>
+
+	
+	
+  <p id="comments_link">
+    Questions or comments? Email Nick Doty at <a href="mailto:npdoty@ischool.berkeley.edu" title="Email Nick Doty">npdoty@ischool.berkeley.edu</a>.
+    <br />Corrections or additions? <a href="https://github.com/m0hit/privacypatterns/wiki/Unusual-activities" target="_blank">Contribute via Github!</a>
+  </p>
+  
+
+  <div id="disqus_thread"></div>
+  <script type="text/javascript">
+      /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+      var disqus_shortname = 'privacypatterns';
+      // var disqus_developer = 1; // Remove this when going live
+
+      /* * * DON'T EDIT BELOW THIS LINE * * */
+      (function() {
+          var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+          dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+      })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+
+</div>
+
+
+
+      </div>
+			<footer>
+	<p>
+		<a rel="license" class="license" href="http://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" src="http://i.creativecommons.org/l/by/3.0/80x15.png" /></a>
+		Privacy patterns are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution license</a>.
+	<br>Contribute at <a href="https://github.com/m0hit/privacypatterns">github</a>. Read our <a href="/about/policy" title="Privacy Policy">privacy and contribution policy</a>.
+	</p>
+	<p class="berkeley">UC Berkeley <img id="iman" src="/media/images/I_School_logo_i.png" height="30px" /> School of Information</p> 
+</footer>
+
+
+		</div>
+    <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if necessary --
+    
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.js"></script>
+    <script>window.jQuery || document.write("<script src='js/libs/jquery-1.5.1.min.js'>\x3C/script>")</script>
+    
+  	
+  	
+    -->
+    <script>
+      var _gaq=[['_setAccount','UA-24350461-1'],['_trackPageview']];
+      (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
+        g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g,s)}(document,'script'));
+    </script>
+	</body>
+</html>
+

--- a/site/deploy/patterns/Unusual-activities.md
+++ b/site/deploy/patterns/Unusual-activities.md
@@ -1,0 +1,250 @@
+[TOC]
+
+## Intent
+
+For Internet services, prevent suspicious access to the account, and/or
+make the account owner aware of unusual activities.
+
+## Context
+
+Many Internet services are using password-based authentication which is
+really convenient (compared to strong authentication) but has apparent
+drawbacks:
+
+-   The password itself does not change.
+
+    Unless the account owner changes the password, all sign-ins use the
+    same identity-password combination. If the password is stolen by a
+    malicious party through some means, it can be reused until it is
+    changed.
+
+-   The password can be cracked.
+
+    Many account owners tend to use weak passwords that can be
+    brute-force attacked online. Sometimes the hacker can obtain the
+    database dump which contains hashed passwords, which can be
+    brute-forced offline.
+
+-   The account owner has no way to ensure their exclusive possession of
+    the password.
+
+    The account owner has no evidence if the password is stolen by a
+    malicious party.
+
+-   The only way to control who can access is to reset the password.
+
+    As a result, if the account owner want to ensure only they have the
+    password, they can only reset the password. In some scenarios,
+    resetting the password is not enough.
+
+-   The password can be seen by people around.
+
+    When the account owner enters the password on a computer keyboard or
+    the screen of a mobile device (mobile phone / tablet), people around
+    have the ability to snoop the password and record it.
+
+Thus, a service can't tell if the user is legitimate even if the
+identity-password combination provided by the user is correct.
+Fortunately, a service can usually receive some meta information to help
+determine if an activity is unusual. In case of such unusual activities,
+a service needs to prevent suspicious access to an account, and/or
+inform the account owner of the unusual activities.
+
+## Problem
+
+How can a service that uses username-password authentication and
+involves a lot of privacy identify unusual sign-ins, confirm the
+identify of the user, and inform the account owner of such unusual
+activities?
+
+## Solutions
+
+First, the service should be able to identify unusual sign-ins Then the
+service may use multi-factor authentication to confirm the identity of
+the user.
+
+The user should be informed of unusual activites, or have some ways to
+see recent events, and even do something.
+
+### Identify Unusual Activities
+
+Today, a web service may appear as a website or an application on the
+user's devices (including mobile devices and the PCs). The service can
+use meta information to determine if a sign-in with the correct
+username-password combination is suspicious.
+
+The strategies described here has both false positives and false
+negatives.
+
+#### A Website
+
+Typically, a sign-in to a website is in the form of an HTTP request,
+which contains many customized settings of the browser, including the
+type of the browser and operating system as well as the architecture
+(`User-Agent` header), the Cookie (`Cookie` header), language
+preferences (`Accept-Languages` header). Apart from these, the website
+can get the IP address of the user, which may be mapped to a certain
+country/area through GeoIP.
+
+The above meta information can be used to tell if a browser is *new* to
+the website. The website can have its rules to determine if an access is
+*suspicious*, for example, an access from a new country / browser /
+operating system is considered suspicious.
+
+#### An Application
+
+By running native code, the application can collect some identifiers of
+the machine, including the operating system environment settings (e.g.
+the list of running processes), the hardware parameters (such as the ID
+of the CPU), and device UUIDs (provided by mobile operating systems like
+iOS). By completing a network request, the service also retrieves the IP
+address of the machine.
+
+The above meta information can be used to tell if a machine is *new* to
+the service. The service can have its rules to determine if a sign-in is
+*suspicious*, for example, an access from a new country / machine /
+operating system is considered suspicious.
+
+### Require Multi-factor Authentication
+
+In case of a suspicious sign-in, multi-factor authentication may be a
+way to let the legitimate user in. The service can request one more
+authentication except password, such as:
+
+-   A software token
+
+    Examples include Google Authenticator which runs on mobile phones
+    and implements RFC6238 TOTP security tokens..
+
+-   A hardware token (disconnected)
+
+    Examples include a token issued by a bank which displays digits,
+    which is similar to a software token.
+
+-   A hardware token (connected)
+
+    The token may exchange a longer secondary password than the previous
+    one, which means it's safer.
+
+-   Personal data like date of birth, SSN
+
+    Obviously not a good choice here because it cannot be changed.
+
+-   An one-time password (OTP) sent to the registered E-mail address /
+    mobile phone
+
+    Depending the type of the service, maybe the user uses the same
+    password for the E-mail address, or maybe the mobile phone is stolen
+    and the service runs on the mobile phone.
+
+Using multi-factor authentication only in case of suspicious sign-ins is
+more convenient to using it all the time, but is less secure.
+
+### Notify Account Holders of Unusual Activities
+
+When an suspicious sign-in is detected, it may be a sign that the
+password has already been leaked. Depending on the type of the service,
+it can notify the user about the suspicious sign-in through E-mail,
+telephone, or other means.
+
+Here the immediate notification can also be used in the multi-factor
+authentication.
+
+For services that can be logged on from multiple devices at the same
+time, the user should be able to check the existence of other sessions,
+and review recent sign-in events.
+
+## Examples
+
+### Gmail
+
+Gmail displays information about other sessions (if any) in the footer,
+linking to a page named "Activity on this account" which lists other
+sessions and recent activities to the Gmail account. The user has the
+option to sign out other sessions.
+
+In case of annoying false positives, the user may choose to disable the
+alert for unusual activity. The disable takes about a week, "to make
+sure the bad guys aren't the ones who turned off your alerts."
+
+### Facebook
+
+When Facebook detects an unusual sign-in, it shows *social
+authentication* that displays a few pictures of the user's friends and
+asks the user to name the person in those photos.
+
+### Dropbox
+
+The *Security* tab of the *Settings* of the Dropbox website displays all
+web browser sessions logged in to the account, and enables the user to
+log out one or more of them. The name of the browser, operating system,
+and the IP address and corresponding country are displayed to help the
+user make a choice.
+
+It also displays all devices that are linked to the account, and allows
+the user to unlink one or more of them.
+
+## Forces/Concerns
+
+The pattern described here is a tradeoff between pure password
+authentication which is insecure, and pure multi-factor authentication
+which is inconvenient. It increases privacy at the cost of usability.
+
+The fallback multi-factor authentication should be picked carefully with
+the understanding of the service.
+
+-   In the above example, Facebook makes use of its resource of
+    friendship and photos. Their decision is based on the assumption
+    that it is very unlikely for a hacker to recognize the friends.
+    Actually the assumption may not hold true in some scenarios, because
+    many of the photos are public and can be viewed under another
+    account, or can be identified with the help from a large-scale
+    tagged photo collection and machine learning.
+-   Persuading the user into carrying a hardware token everywhere only
+    for occasional multi-factor authentication may be difficult, but it
+    might worth the effort for financial services.
+
+The strategy to identify unusual activities should also be considered
+seriously. It should be also to identify most of the activities, with a
+false positive rate that is not too high. It should balance the cost of
+multi-factor authentication.
+
+Reflection on the Process
+-------------------------
+
+### Determining the Scope
+
+I started with Gmail's display of account activities. It displays
+unusual activities regarding an account, which involves identifying
+unusual activities where the password entered is correct. For some other
+services, correct passwords can be rejected from a new device /
+location.
+
+So, the scope of this pattern is to handle unusual activities (including
+sign-ins).
+
+### Relevant Information
+
+This pattern includes multi-factor authentication and two-step
+authentication, which are well studied. But the general topic about
+informing the user of unusual activites seems to be lack of literature.
+
+### Limitations and Discussion
+
+This pattern has some limitations. For example, it relies on accurate
+identification of suspicious sign-ins based on meta information, where
+the meta information including the IP address can be spoofed by an
+experienced attacker.
+
+If the fallback multi-factor authentication only happens occationally to
+the legitimate account owner, they may be unprepared to such
+authentication, leading to a decreased usability.
+
+References
+----------
+
+-   Polakis, I., Lancini, M., Kontaxis, G., Maggi, F., Ioannidis, S.,
+    Keromytis, A. D., & Zanero, S. (2012, December). **All Your Face are
+    Belong to Us: Breaking Facebook's Social Authentication**. In
+    *Proceedings of the 28th Annual Computer Security Applications
+    Conference* (pp. 399-408). ACM.

--- a/site/deploy/patterns/index.html
+++ b/site/deploy/patterns/index.html
@@ -87,35 +87,43 @@
 	
 		
 
-<ul id="patterns_listing"><li><a href="/patterns/Active-broadcast-of-presence"><h3>
-    		  		
-    						Active broadcast of presence
-    					
-  					</h3><p class="">Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p></a></li><li><a href="/patterns/Ambient-notice"><h3>
-    		  		
-    						Ambient notice
-    					
-  					</h3><p class="">Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p></a></li><li><a href="/patterns/Asynchronous-notice"><h3>
-    		  		
-    						Asynchronous notice
-    					
-  					</h3><p class="">How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p></a></li><li><a href="/patterns/Location-granularity"><h3>
+<ul id="patterns_listing"><li><a href="/patterns/Location-granularity"><h3>
     		  		
     						Location Granularity
     					
-  					</h3><p class="">Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p></a></li><li><a href="/patterns/Privacy-dashboard"><h3>
-    		  		
-    						Privacy dashboard
-    					
-  					</h3><p class="">An informational privacy dashboard can provide collected summaries of the collected or processed personal data for a particular user.</p></a></li><li><a href="/patterns/Private-link"><h3>
+  					</h3><p class="">Support minimization of data collection and distribution. Important when a service is collecting location data from or about a user, or transmitting location data about a user to a third-party.</p></a></li><li><a href="/patterns/Private-link"><h3>
     		  		
     						Private link
     					
-  					</h3><p class="empty">No excerpt</p></a></li><li><a href="/patterns/Strip-invisible-metadata"><h3>
+  					</h3><p class="empty">No excerpt</p></a></li><li><a href="/patterns/Privacy-dashboard"><h3>
+    		  		
+    						Privacy dashboard
+    					
+  					</h3><p class="">An informational privacy dashboard can provide collected summaries of the collected or processed personal data for a particular user.</p></a></li><li><a href="/patterns/Unusual-activities"><h3>
+    		  		
+    						Handling unusual account activities with multiple factors
+    					
+  					</h3><p class="">Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.</p></a></li><li><a href="/patterns/Asynchronous-notice"><h3>
+    		  		
+    						Asynchronous notice
+    					
+  					</h3><p class="">How can a service effectively provide notice to a user who gave permission once but whose information is accessed repeatedly (perhaps even continuously) over a long period of time? Proactively notify the user after the time of consent that information is being tracked, stored or re-distributed.</p></a></li><li><a href="/patterns/Encryption-user-managed-keys"><h3>
+    		  		
+    						Encryption with user-managed keys
+    					
+  					</h3><p class="">Use encryption in such a way that the service provider cannot decrypt the user&#39;s information because the user manages the keys.</p></a></li><li><a href="/patterns/Active-broadcast-of-presence"><h3>
+    		  		
+    						Active broadcast of presence
+    					
+  					</h3><p class="">Users may choose actively when they want to share presence information, to increase both the relevance of, and control over, sharing.</p></a></li><li><a href="/patterns/Strip-invisible-metadata"><h3>
     		  		
     						Strip Invisible Metadata
     					
-  					</h3><p class="">Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p></a></li></ul>
+  					</h3><p class="">Strip potentially sensitive metadata that isn&#39;t directly visible to the end user.</p></a></li><li><a href="/patterns/Ambient-notice"><h3>
+    		  		
+    						Ambient notice
+    					
+  					</h3><p class="">Provide an ambient notice (unobtrusive, non-modal) when location is being accessed to increase awareness of ongoing tracking.</p></a></li></ul>
 
 
 	
@@ -147,6 +155,9 @@
 <a href="/categories/access" class="access">access</a></li>
     
       <li>
+<a href="/categories/authentication" class="authentication">authentication</a></li>
+    
+      <li>
 <a href="/categories/ui" class="ui">ui</a></li>
     
       <li>
@@ -156,7 +167,13 @@
 <a href="/categories/transparency" class="transparency">transparency</a></li>
     
       <li>
+<a href="/categories/encryption" class="encryption">encryption</a></li>
+    
+      <li>
 <a href="/categories/distribution" class="distribution">distribution</a></li>
+    
+      <li>
+<a href="/categories/cloud" class="cloud">cloud</a></li>
     
       <li>
 <a href="/categories/metadata" class="metadata">metadata</a></li>

--- a/test
+++ b/test
@@ -1,2 +1,0 @@
-testing
-testing


### PR DESCRIPTION
* small change in wiki to Private-link

*This was already deployed to the privacypatterns.org site a couple of years ago.*

Wondering if we really need to store the content from the wiki in the main repository also. Makes it easy for them to get out of sync. We should probably keep the raw data in one place only. 