### PR TITLE
Use repo as raw source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:alpine
+FROM httpd:2-alpine
 
-COPY ./site/deploy /html
-WORKDIR /html
+RUN apk add --no-cache sed
+RUN sed -i '/Options Indexes FollowSymLinks/c Options Indexes MultiViews' /usr/local/apache2/conf/httpd.conf
+COPY ./site/deploy /usr/local/apache2/htdocs/
 
-CMD ["python", "-m", "http.server", "80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM httpd:2-alpine
 
 RUN apk add --no-cache sed
 RUN sed -i '/Options Indexes FollowSymLinks/c Options Indexes MultiViews' /usr/local/apache2/conf/httpd.conf
+RUN sed -i 's/^#LoadModule negotiation_module/LoadModule negotiation_module/' /usr/local/apache2/conf/httpd.conf
 COPY ./site/deploy /usr/local/apache2/htdocs/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: build wiki-clone docker static
+.PHONY: build docker static
 
 build: ./site/content/patterns
 static: ./site/deploy
@@ -7,14 +7,14 @@ static: ./site/deploy
 docker:
 	@docker build .
 
-./privacypatterns.wiki: wiki-clone
+./patterns:
 	@echo "Updating content from wiki"
 	@[ -d $@ ] || git clone https://github.com/privacypatterns/$@.git
 	@cd $@ && git checkout master && git pull
 
-./site/content/patterns: ./privacypatterns.wiki
+./site/content/patterns: ./patterns
 	@echo "Generating static files"
-	@python markdown_to_hyde.py -s ./privacypatterns.wiki -d ./site/content/
+	@python markdown_to_hyde.py -s ./patterns -d ./site/content/
 
 ./hyde/hyde.py:
 	@echo "Getting hyde"


### PR DESCRIPTION
1. use https://github.com/privacypatterns/patterns as the source for patterns
2. use apache2 instead of pythin in docker container to support navigation without `.html` in URLs