### PR TITLE
Allow stub patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ sync: ./patterns
 	@echo "Cloning content from $(SOURCE_PATTERNS_REPO)"
 	@[ -d ./patterns ] || git clone $(SOURCE_PATTERNS_REPO)
 
-./site/content/patterns: ./patterns
+./site/content/patterns: ./patterns ./site/content/patterns/index.html ./site/layout/*
 	@echo "Generating static files"
 	@python markdown_to_hyde.py -s ./patterns -d ./site/content/
 

--- a/site/content/index.html
+++ b/site/content/index.html
@@ -21,7 +21,7 @@
   <h2>Popular Patterns</h2>
 	<ul id="patterns_listing">
 		{% for post in recents %}
-		  {% if post.display_in_list %}
+		  {% if post.display_in_list and post.status != "stub" %}
   			<li>
   				<a href='{{post.url}}'>
   				  <h3>{{post.title}}</h3>

--- a/site/deploy/categories/abstract/index.html
+++ b/site/deploy/categories/abstract/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Location-granularity">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/access/index.html
+++ b/site/deploy/categories/access/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Private-link">
 			  <h3>
@@ -105,6 +106,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Privacy-dashboard">
@@ -119,6 +122,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/aggregate/index.html
+++ b/site/deploy/categories/aggregate/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Trustworthy-privacy-plugin">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Aggregation-gateway">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/anonymity/index.html
+++ b/site/deploy/categories/anonymity/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-identity">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Protection-against-tracking">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/attribute-based-credentials">
 			  <h3>
@@ -136,6 +141,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Anonymity-set">
 			  <h3>
@@ -149,6 +156,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/anonymous-communication/index.html
+++ b/site/deploy/categories/anonymous-communication/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Onion-routing">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/authentication/index.html
+++ b/site/deploy/categories/authentication/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Unusual-activities">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/attribute-based-credentials">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/choose/index.html
+++ b/site/deploy/categories/choose/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Private-link">
 			  <h3>
@@ -105,6 +106,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Active-broadcast-of-presence">
@@ -119,6 +122,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/cloud/index.html
+++ b/site/deploy/categories/cloud/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/control/index.html
+++ b/site/deploy/categories/control/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Data-breach-notification-pattern">
 			  <h3>
@@ -108,17 +109,7 @@
 			</a>
 		</li>
   
-		<li>
-		  <a href="/patterns/Private-link">
-			  <h3>
-		  		
-						Private link
-					
-				</h3>
-
-				
-			</a>
-		</li>
+  
   
 		<li>
 		  <a href="/patterns/Private-link">
@@ -131,6 +122,22 @@
 				
 			</a>
 		</li>
+  
+  
+  
+		<li>
+		  <a href="/patterns/Private-link">
+			  <h3>
+		  		
+						Private link
+					
+				</h3>
+
+				
+			</a>
+		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Unusual-activities">
@@ -146,6 +153,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
@@ -159,6 +168,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Policy-matching-display">
@@ -174,6 +185,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Privacy-color-coding">
 			  <h3>
@@ -187,6 +200,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Active-broadcast-of-presence">
@@ -202,6 +217,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Personal-data-store">
 			  <h3>
@@ -215,6 +232,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/cookies/index.html
+++ b/site/deploy/categories/cookies/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Protection-against-tracking">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/create/index.html
+++ b/site/deploy/categories/create/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Federated-privacy-impact-assessment">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/data-minimization/index.html
+++ b/site/deploy/categories/data-minimization/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/User-data-confinement-pattern">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/dissociate/index.html
+++ b/site/deploy/categories/dissociate/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-identity">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-messaging">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/distraction/index.html
+++ b/site/deploy/categories/distraction/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-color-coding">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/distribution/index.html
+++ b/site/deploy/categories/distribution/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Private-link">
 			  <h3>
@@ -105,6 +106,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/email/index.html
+++ b/site/deploy/categories/email/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-messaging">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/encryption/index.html
+++ b/site/deploy/categories/encryption/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/enforce/index.html
+++ b/site/deploy/categories/enforce/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/identity-federation-do-not-track-pattern">
 			  <h3>
@@ -109,6 +110,8 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/sticky-policy">
 			  <h3>
@@ -122,6 +125,8 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Federated-privacy-impact-assessment">
@@ -137,6 +142,8 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Obligation-management">
 			  <h3>
@@ -150,6 +157,7 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/exclude/index.html
+++ b/site/deploy/categories/exclude/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Protection-against-tracking">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/exif/index.html
+++ b/site/deploy/categories/exif/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/explain/index.html
+++ b/site/deploy/categories/explain/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-aware-network-client">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Layered-policy-design">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Privacy-icons">
 			  <h3>
@@ -136,6 +141,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Privacy-color-coding">
 			  <h3>
@@ -149,6 +156,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/group/index.html
+++ b/site/deploy/categories/group/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Location-granularity">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/hide/index.html
+++ b/site/deploy/categories/hide/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Use-of-dummies">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Anonymous-reputation-based-blacklisting">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Trustworthy-privacy-plugin">
 			  <h3>
@@ -135,6 +140,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Onion-routing">
@@ -150,6 +157,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-identity">
 			  <h3>
@@ -163,6 +172,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Pseudonymous-messaging">
@@ -178,6 +189,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
@@ -191,6 +204,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/attribute-based-credentials">
@@ -206,6 +221,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Anonymity-set">
 			  <h3>
@@ -219,6 +236,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Added-noise-measurement-obfuscation">
@@ -234,6 +253,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Aggregation-gateway">
 			  <h3>
@@ -247,6 +268,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/identity-management/index.html
+++ b/site/deploy/categories/identity-management/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/identity-federation-do-not-track-pattern">
 			  <h3>
@@ -108,6 +109,7 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/inform/index.html
+++ b/site/deploy/categories/inform/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-aware-network-client">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Data-breach-notification-pattern">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Privacy-dashboard">
 			  <h3>
@@ -135,6 +140,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Layered-policy-design">
@@ -150,6 +157,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Unusual-activities">
 			  <h3>
@@ -163,6 +172,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Asynchronous-notice">
@@ -178,6 +189,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Privacy-icons">
 			  <h3>
@@ -191,6 +204,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Policy-matching-display">
@@ -206,6 +221,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Privacy-color-coding">
 			  <h3>
@@ -220,6 +237,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Ambient-notice">
 			  <h3>
@@ -233,6 +252,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/isolate/index.html
+++ b/site/deploy/categories/isolate/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/User-data-confinement-pattern">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Personal-data-store">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/location/index.html
+++ b/site/deploy/categories/location/index.html
@@ -98,6 +98,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Location-granularity">
 			  <h3>
@@ -111,6 +112,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Privacy-dashboard">
@@ -126,6 +129,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Asynchronous-notice">
 			  <h3>
@@ -139,6 +144,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Active-broadcast-of-presence">
@@ -154,6 +161,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
@@ -168,6 +177,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Ambient-notice">
 			  <h3>
@@ -181,6 +192,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/media/index.html
+++ b/site/deploy/categories/media/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Private-link">
 			  <h3>
@@ -105,6 +106,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
@@ -119,6 +122,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/messaging/index.html
+++ b/site/deploy/categories/messaging/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-messaging">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/metadata/index.html
+++ b/site/deploy/categories/metadata/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/minimization/index.html
+++ b/site/deploy/categories/minimization/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Location-granularity">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/minimize/index.html
+++ b/site/deploy/categories/minimize/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Protection-against-tracking">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/attribute-based-credentials">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Added-noise-measurement-obfuscation">
 			  <h3>
@@ -136,6 +141,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
@@ -149,6 +156,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/mix-networks/index.html
+++ b/site/deploy/categories/mix-networks/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Anonymity-set">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/mix/index.html
+++ b/site/deploy/categories/mix/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Onion-routing">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Anonymity-set">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/mobile/index.html
+++ b/site/deploy/categories/mobile/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Asynchronous-notice">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Encryption-user-managed-keys">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Active-broadcast-of-presence">
 			  <h3>
@@ -136,6 +141,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Ambient-notice">
 			  <h3>
@@ -149,6 +156,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/notice/index.html
+++ b/site/deploy/categories/notice/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Unusual-activities">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Asynchronous-notice">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Ambient-notice">
 			  <h3>
@@ -135,6 +140,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/notify/index.html
+++ b/site/deploy/categories/notify/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Data-breach-notification-pattern">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Unusual-activities">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Asynchronous-notice">
 			  <h3>
@@ -136,6 +141,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Ambient-notice">
 			  <h3>
@@ -149,6 +156,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/obfuscate/index.html
+++ b/site/deploy/categories/obfuscate/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Use-of-dummies">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Added-noise-measurement-obfuscation">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/obfuscation/index.html
+++ b/site/deploy/categories/obfuscation/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Anonymity-set">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/p3p/index.html
+++ b/site/deploy/categories/p3p/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-aware-network-client">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/privacy-policy/index.html
+++ b/site/deploy/categories/privacy-policy/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-aware-network-client">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Privacy-icons">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/sticky-policy">
 			  <h3>
@@ -135,6 +140,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/procedure/index.html
+++ b/site/deploy/categories/procedure/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Federated-privacy-impact-assessment">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/provide/index.html
+++ b/site/deploy/categories/provide/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-dashboard">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Policy-matching-display">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/proxy/index.html
+++ b/site/deploy/categories/proxy/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-aware-network-client">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/pseudonymity/index.html
+++ b/site/deploy/categories/pseudonymity/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-identity">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Pseudonymous-messaging">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/restrict/index.html
+++ b/site/deploy/categories/restrict/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Anonymous-reputation-based-blacklisting">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/Trustworthy-privacy-plugin">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Encryption-user-managed-keys">
 			  <h3>
@@ -135,6 +140,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/attribute-based-credentials">
@@ -150,6 +157,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Aggregation-gateway">
 			  <h3>
@@ -163,6 +172,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/risk-management/index.html
+++ b/site/deploy/categories/risk-management/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Federated-privacy-impact-assessment">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/routing/index.html
+++ b/site/deploy/categories/routing/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Onion-routing">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/separate/index.html
+++ b/site/deploy/categories/separate/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Anonymous-reputation-based-blacklisting">
 			  <h3>
@@ -107,6 +108,8 @@
 				
 			</a>
 		</li>
+  
+  
   
 		<li>
 		  <a href="/patterns/User-data-confinement-pattern">
@@ -122,6 +125,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Personal-data-store">
 			  <h3>
@@ -135,6 +140,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/strip/index.html
+++ b/site/deploy/categories/strip/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Strip-invisible-metadata">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/tracking/index.html
+++ b/site/deploy/categories/tracking/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Protection-against-tracking">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/transparency/index.html
+++ b/site/deploy/categories/transparency/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-dashboard">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/unlinkability/index.html
+++ b/site/deploy/categories/unlinkability/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Protection-against-tracking">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/uphold/index.html
+++ b/site/deploy/categories/uphold/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/identity-federation-do-not-track-pattern">
 			  <h3>
@@ -109,6 +110,8 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/sticky-policy">
 			  <h3>
@@ -123,6 +126,8 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Obligation-management">
 			  <h3>
@@ -136,6 +141,7 @@ The Do Not Track Pattern makes sure that neither the Identity Provider nor the I
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/user-interface/index.html
+++ b/site/deploy/categories/user-interface/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-color-coding">
 			  <h3>
@@ -108,6 +109,8 @@
 			</a>
 		</li>
   
+  
+  
 		<li>
 		  <a href="/patterns/Ambient-notice">
 			  <h3>
@@ -121,6 +124,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/visualize/index.html
+++ b/site/deploy/categories/visualize/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/Privacy-color-coding">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/deploy/categories/zero-knowledge/index.html
+++ b/site/deploy/categories/zero-knowledge/index.html
@@ -94,6 +94,7 @@
   
   <ul id="patterns_listing">
   
+  
 		<li>
 		  <a href="/patterns/attribute-based-credentials">
 			  <h3>
@@ -107,6 +108,7 @@
 				
 			</a>
 		</li>
+  
   
   </ul>
 

--- a/site/layout/_category.html
+++ b/site/layout/_category.html
@@ -22,6 +22,7 @@
   
   <ul id="patterns_listing">
   {% for post in posts %}
+  {% if post.status != "stub" %}
 		<li>
 		  <a href="{{post.url}}">
 			  <h3>
@@ -35,6 +36,7 @@
 				{%endif%}
 			</a>
 		</li>
+  {% endif %}
   {% endfor %}
   </ul>
 {% endblock %}

--- a/site/layout/skeleton/_innerlisting.html
+++ b/site/layout/skeleton/_innerlisting.html
@@ -13,7 +13,7 @@
 <ul id="patterns_listing">
     {% for list_page in node.pages %}
 		{% ifnotequal list_page node.listing_page %}
-			{% if list_page.display_in_list %}
+			{% if list_page.display_in_list and list_page.status != "stub" %}
 				<li>
 				  <a href="{{list_page.url}}">
   				  <h3>


### PR DESCRIPTION
* add support for unlisted patterns that have hyde tag `status: stub`

Look at commit: https://github.com/privacypatterns/privacypatterns/pull/76/commits/cad10b552b99a19a4403cfb75c96e30f7270d11a for actual changes. 

The other commit is just lots of line additions due to django template :/


*See example: https://github.com/privacypatterns/privacypatterns/compare/allow-stub-patterns...stub-test*