### PR TITLE
update list of collaborators and support

### DIFF
--- a/site/deploy/about/about.md
+++ b/site/deploy/about/about.md
@@ -10,21 +10,29 @@ Drawing inspiration from Christopher Alexander and the success of software desig
 * document common solutions to privacy problems
 * help designers identify and address privacy concerns
 
-We're currently compiling some patterns to get started, but our goal is for this to be a living document constructed by the community of engineers, designers, lawyers and regulators involved in this topic. 
+Our goal is for this to be a living document constructed by the community of engineers, designers, lawyers and regulators involved in this topic. 
 
 ## Team
 
-[Nick Doty](https://npdoty.name) is a PhD candidate at the [UC Berkeley, School of Information](https://www.ischool.berkeley.edu/) and works on [privacy in Web standards](https://www.w3.org/Privacy/).
+This project is a collaboration of:
 
-[Mohit Gupta](http://mohitgupta.me) works with engineering at the education technology platform [Clever](https://clever.com).
+* Michael Colesky and Jaap-Henk Hoepman, [Radboud University](http://www.ru.nl)
+* Christoph Boesch, Frank Kargl, Henning Kopp and Patrick Mosby, [Ulm University](https://www.uni-ulm.de)
+* Daniel Le Métayer, [Inria](https://www.inria.fr)
+* Olha Drozd, [Vienna University of Economics and Business](https://www.wu.ac.at)
+* José M. del Álamo and Yod Samuel Martín, [Universidad Politécnica de Madrid](http://www.upm.es)
+* Mohit Gupta, [Clever](http://www.clever.com)
+* Nick Doty, [UC Berkeley School of Information](https://www.ischool.berkeley.edu/)
 
-[Jeff Zych](http://jlzych.com) and [Rowyn McDonald](http://www.rowyn.com) designed this site.
+[Jeff Zych](http://jlzych.com) and [Rowyn McDonald](http://www.rowyn.com) helped to design this site; issues and pull requests are welcome at [GitHub](https://github.com/privacypatterns/privacypatterns). [Contributions of patterns](https://github.com/privacypatterns/patterns) are also welcome.
 
 ## Support
 
 This material is based in part upon work supported by the U.S. Department of Homeland Security under grant award #2006-CS-001-000001 and the National Institute of Standards and Technology, under grant award #60NANB1D0127, under the auspices of the [Institute for Information Infrastructure Protection](http://www.thei3p.org/) (I3P) research program. The I3P is managed by Dartmouth College. The views and conclusions contained in this document are those of the authors and should not be interpreted as necessarily representing the official policies, either expressed or implied, of the U.S. Department of Homeland Security, the I3P, or Dartmouth College.
 
 The Berkeley Center for Law and Technology supported this research in part in conjunction with a research gift from Nokia.
+
+This work was supported by the European Union’s Seventh Framework Programme (FP7), via the [PRIPARE project](http://pripareproject.eu/).
 
 ## Contact us
 

--- a/site/deploy/about/index.html
+++ b/site/deploy/about/index.html
@@ -94,14 +94,23 @@
 <li>document common solutions to privacy&nbsp;problems</li>
 <li>help designers identify and address privacy&nbsp;concerns</li>
 </ul>
-<p>We're currently compiling some patterns to get started, but our goal is for this to be a living document constructed by the community of engineers, designers, lawyers and regulators involved in this&nbsp;topic. </p>
+<p>Our goal is for this to be a living document constructed by the community of engineers, designers, lawyers and regulators involved in this&nbsp;topic. </p>
 <h2 id="team"><a class="toclink" href="#team">Team</a></h2>
-<p><a href="https://npdoty.name">Nick Doty</a> is a PhD candidate at the <a href="https://www.ischool.berkeley.edu/">UC Berkeley, School of Information</a> and works on <a href="https://www.w3.org/Privacy/">privacy in Web standards</a>.</p>
-<p><a href="http://mohitgupta.me">Mohit Gupta</a> works with engineering at the education technology platform <a href="https://clever.com">Clever</a>.</p>
-<p><a href="http://jlzych.com">Jeff Zych</a> and <a href="http://www.rowyn.com">Rowyn McDonald</a> designed this&nbsp;site.</p>
+<p>This project is a collaboration&nbsp;of:</p>
+<ul>
+<li>Michael Colesky and Jaap-Henk Hoepman, <a href="http://www.ru.nl">Radboud&nbsp;University</a></li>
+<li>Christoph Boesch, Frank Kargl, Henning Kopp and Patrick Mosby, <a href="https://www.uni-ulm.de">Ulm&nbsp;University</a></li>
+<li>Daniel Le Métayer, <a href="https://www.inria.fr">Inria</a></li>
+<li>Olha Drozd, <a href="https://www.wu.ac.at">Vienna University of Economics and&nbsp;Business</a></li>
+<li>José M. del Álamo and Yod Samuel Martín, <a href="http://www.upm.es">Universidad Politécnica de&nbsp;Madrid</a></li>
+<li>Mohit Gupta, <a href="http://www.clever.com">Clever</a></li>
+<li>Nick Doty, <a href="https://www.ischool.berkeley.edu/">UC Berkeley School of&nbsp;Information</a></li>
+</ul>
+<p><a href="http://jlzych.com">Jeff Zych</a> and <a href="http://www.rowyn.com">Rowyn McDonald</a> helped to design this site; issues and pull requests are welcome at <a href="https://github.com/privacypatterns/privacypatterns">GitHub</a>. <a href="https://github.com/privacypatterns/patterns">Contributions of patterns</a> are also&nbsp;welcome.</p>
 <h2 id="support"><a class="toclink" href="#support">Support</a></h2>
 <p>This material is based in part upon work supported by the U.S. Department of Homeland Security under grant award #2006-CS-001-000001 and the National Institute of Standards and Technology, under grant award #60NANB1D0127, under the auspices of the <a href="http://www.thei3p.org/">Institute for Information Infrastructure Protection</a> (I3P) research program. The I3P is managed by Dartmouth College. The views and conclusions contained in this document are those of the authors and should not be interpreted as necessarily representing the official policies, either expressed or implied, of the U.S. Department of Homeland Security, the I3P, or Dartmouth&nbsp;College.</p>
 <p>The Berkeley Center for Law and Technology supported this research in part in conjunction with a research gift from&nbsp;Nokia.</p>
+<p>This work was supported by the European Union’s Seventh Framework Programme (FP7), via the <a href="http://pripareproject.eu/">PRIPARE project</a>.</p>
 <h2 id="contact-us"><a class="toclink" href="#contact-us">Contact&nbsp;us</a></h2>
 <p>If you're interested in privacy patterns &mdash; because you'd like to contribute your own content, support the project in some way or suggest an improvement &mdash; please contact Nick Doty at <a href="mailto:npdoty@ischool.berkeley.edu">npdoty@ischool.berkeley.edu</a>.</p>
 	


### PR DESCRIPTION
added in the names and affiliations of all collaborators (thanks @p4pnl) with links, to address #63. collaborators were ordered randomly, as I'm not sure we have a particular meaningful ordering in mind.

didn't include logo images, as I wasn't sure how to quickly make them look nice in this template and I wasn't sure if they were necessary for now

updated the funding section to mention PRIPARE / FP7