### PR TITLE
This should fix hyde's generated HTML for this one example

### DIFF
--- a/site/content/patterns/Location-granularity.md
+++ b/site/content/patterns/Location-granularity.md
@@ -60,30 +60,30 @@ In some cases, less granular data may also better capture the intent of a user (
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
-1. _Fire Eagle location hierarchy_
+1. _Fire Eagle location hierarchy_  
 
- ![Fire Eagle granularity screenshot](/media/images/Fire_Eagle_granularity.png)
+   ![Fire Eagle granularity screenshot](/media/images/Fire_Eagle_granularity.png)  
 
- Yahoo! Fire Eagle allows user to provide location information to applications using eight different "levels" of granularity in their [hierarchy](http://fireeagle.yahoo.net/developer/documentation/location): 
+   Yahoo! Fire Eagle allows user to provide location information to applications using eight different "levels" of granularity in their [hierarchy](http://fireeagle.yahoo.net/developer/documentation/location):  
 
- * No information
- * As precise as possible
- * Postal code
- * Neighborhood
- * Town
- * Region
- * State
- * Country
+   * No information
+   * As precise as possible
+   * Postal code
+   * Neighborhood
+   * Town
+   * Region
+   * State
+   * Country
 
- Fire Eagle specifically requires that recipient applications be written to handle data at any of the levels, and allows updating the user's location at any level of granularity.
+   Fire Eagle specifically requires that recipient applications be written to handle data at any of the levels, and allows updating the user's location at any level of granularity.
 
-2. _Twitter "place" vs. "exact location"_
+2. _Twitter "place" vs. "exact location"_  
 
- [Twitter](https://support.twitter.com/articles/78525-about-the-tweet-location-feature) allows users to tag a tweet with either exact coordinates, a Twitter "place" (a town, neighborhood or venue) or both.
+   [Twitter](https://support.twitter.com/articles/78525-about-the-tweet-location-feature) allows users to tag a tweet with either exact coordinates, a Twitter "place" (a town, neighborhood or venue) or both.
 
-3. _Geode_
+3. _Geode_  
 
- One of the fore-runners to the W3C Geolocation API, Firefox's experimental Geode feature allowed JavaScript access to the current location at four different levels of granularity.{{fact}}
+   One of the fore-runners to the W3C Geolocation API, Firefox's experimental Geode feature allowed JavaScript access to the current location at four different levels of granularity.{{fact}}
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->


### PR DESCRIPTION
In addition to extra whitespace for indentation, the indentation level is increased by one and each line (except bullets) include 2 trailing spaces, both as suggested in the markdown cheatsheet