### PR TITLE
Make CSS Responsive

### DIFF
--- a/site/media/css/main.css
+++ b/site/media/css/main.css
@@ -337,6 +337,7 @@ p#cats a:hover { text-decoration: none; }
   margin-right: -43%;
   vertical-align: top;
   top: 0px;
+  position: -webkit-sticky;
   position: sticky;
 }
 

--- a/site/media/css/main.css
+++ b/site/media/css/main.css
@@ -67,12 +67,38 @@ button, input, select, textarea { margin: 0; }
 @font-face { font-family: 'Sorts Mill Goudy'; src:url('/media/fonts/OFLGoudyStMTT.ttf') format("truetype"); }
 
 body {
-  margin: 22px 155px 22px 95px;
+  margin: 22px 95px 22px 95px;
 }
 
 #container {
   max-width: 1064px;
   min-width: 658px;
+  margin: auto;
+}
+
+@media screen and (max-width:855px){
+  body {
+    margin: 2% 8% 2% 8%;
+  }
+  #container {
+    min-width: unset;
+  }
+  #logo {
+    font-size: 5vw !important;
+  }
+  nav {
+    width: auto !important;
+  }
+  h1,h2,h3,.toctitle {
+    font-size: 5vw !important;
+  }
+  #content {
+    width: 100% !important;
+  }
+  .toc {
+    float: none !important;
+    position: inherit !important;
+  }
 }
 
 header {
@@ -104,6 +130,7 @@ h1 a { color: black; }
   font-family: 'Cuprum', serif;
   font-size: 42px;
   width: 62%;
+  min-width: 300px;
 }
 #logo a { color: inherit; text-decoration: none; }
 #logo a:hover { text-decoration: none; }
@@ -308,8 +335,9 @@ p#cats a:hover { text-decoration: none; }
   padding: 1em;
   margin-bottom: 1em;
   margin-right: -43%;
-  width: 40%;
   vertical-align: top;
+  top: 0px;
+  position: sticky;
 }
 
 #content .toc ol, #content .toc ul {


### PR DESCRIPTION
In addition to sticky side menu, make side menu stay at top above content if page width too low. Scale font sizes beyond this point and keep content centered. Site menu should also accommodate the space it is given.

Extends [patterns issue #19](https://github.com/privacypatterns/patterns/issues/19). @npdoty please review/confirm if this (/privacypatterns) is the right project to PR.
