### PR TITLE
Additional RWD CSS

### DIFF
--- a/site/media/css/main.css
+++ b/site/media/css/main.css
@@ -91,6 +91,7 @@ body {
   }
   h1,h2,h3,.toctitle {
     font-size: 5vw !important;
+    line-height: 5vw !important;
   }
   #content {
     width: 100% !important;
@@ -98,6 +99,9 @@ body {
   .toc {
     float: none !important;
     position: inherit !important;
+  }	
+  img {
+    max-width: 100%;
   }
 }
 

--- a/site/media/css/main.css
+++ b/site/media/css/main.css
@@ -103,6 +103,9 @@ body {
   img {
     max-width: 100%;
   }
+  a#lib_button {
+    font-size: 5vw;
+  }
 }
 
 header {
@@ -282,6 +285,7 @@ p#cats a:hover { text-decoration: none; }
   margin: 0 14px 14px 0;
   width: 30%;
   vertical-align: top;
+  min-width: 150px;
 }
 /* #content is only 60% of the page, so lists should be 2 wide */
 #content #patterns_listing li { width: 45%; }


### PR DESCRIPTION
Previously some text at its largest vw size would have insufficient line-height. This change sets line-height to the same as the font-size, which is appropriate for all widths available. Additionally, some images within patterns are too large for certain page widths and thus need (AR respecting) scaling when wider than the page.

@npdoty additional improvements on #81 

Edit: now also accounts for ~300px min with Browse Patterns also resizing, and a min-width (or 150px) to prevent text-overflow on patterns.