### PR TITLE
Handle Single Instances of Emphasis as Italic

### DIFF
--- a/site/media/css/main.css
+++ b/site/media/css/main.css
@@ -125,7 +125,7 @@ h4 { font-size: 18px; font-style: italic; }
 h5 { font-size: 16px; }
 h6 { font-size: 14px; font-weight: bold; }
 
-em { font-weight: bold; }
+em { font-style: italic; }
 
 a { color: #42599E; }
 a:hover { text-decoration: none; }


### PR DESCRIPTION
The same way GitHub handles them. An \__underline_\_ or \**asterisk*\* should be rendered as italic, while two of them should be \*\***bold**\*\*.
As per correspondence @npdoty @mohit 